### PR TITLE
Add return_fields, use cidr to get fixed address

### DIFF
--- a/object_manager.go
+++ b/object_manager.go
@@ -240,19 +240,14 @@ func (objMgr *ObjectManager) AllocateNetwork(netview string, cidr string, prefix
 	return
 }
 
-func (objMgr *ObjectManager) GetFixedAddress(netview string, ipAddr string, macAddr string) (*FixedAddress, error) {
+func (objMgr *ObjectManager) GetFixedAddress(netview string, cidr string, ipAddr string, macAddr string) (*FixedAddress, error) {
 	var res []FixedAddress
 
 	fixedAddr := NewFixedAddress(FixedAddress{
-		NetviewName: netview})
-
-	if ipAddr != "" {
-		fixedAddr.IPAddress = ipAddr
-	}
-
-	if macAddr != "" {
-		fixedAddr.Mac = macAddr
-	}
+		NetviewName: netview,
+		Cidr:        cidr,
+		IPAddress:   ipAddr,
+		Mac:         macAddr})
 
 	err := objMgr.connector.GetObject(fixedAddr, "", &res)
 
@@ -263,9 +258,9 @@ func (objMgr *ObjectManager) GetFixedAddress(netview string, ipAddr string, macA
 	return &res[0], nil
 }
 
-func (objMgr *ObjectManager) ReleaseIP(netview string, ipAddr string, macAddr string) (string, error) {
+func (objMgr *ObjectManager) ReleaseIP(netview string, cidr string, ipAddr string, macAddr string) (string, error) {
 	fmt.Printf("ReleaseIP called: '%s', '%s', '%s'\n", netview, ipAddr, macAddr)
-	fixAddress, _ := objMgr.GetFixedAddress(netview, ipAddr, macAddr)
+	fixAddress, _ := objMgr.GetFixedAddress(netview, cidr, ipAddr, macAddr)
 	fmt.Printf("GetFixedAddress() returns: '%s'\n", fixAddress)
 
 	if fixAddress == nil {

--- a/objects.go
+++ b/objects.go
@@ -46,6 +46,7 @@ type NetworkView struct {
 func NewNetworkView(nv NetworkView) *NetworkView {
 	res := nv
 	res.objectType = "networkview"
+	res.returnFields = []string{"extattrs", "name"}
 
 	return &res
 }
@@ -61,7 +62,7 @@ type Network struct {
 func NewNetwork(nw Network) *Network {
 	res := nw
 	res.objectType = "network"
-	res.returnFields = []string{"extattrs", "network_view", "network"}
+	res.returnFields = []string{"extattrs", "network", "network_view"}
 
 	return &res
 }
@@ -77,6 +78,7 @@ type NetworkContainer struct {
 func NewNetworkContainer(nc NetworkContainer) *NetworkContainer {
 	res := nc
 	res.objectType = "networkcontainer"
+	res.returnFields = []string{"extattrs", "network", "network_view"}
 
 	return &res
 }
@@ -94,6 +96,7 @@ type FixedAddress struct {
 func NewFixedAddress(fixedAddr FixedAddress) *FixedAddress {
 	res := fixedAddr
 	res.objectType = "fixedaddress"
+	res.returnFields = []string{"extattrs", "ipv4addr", "mac", "network", "network_view"}
 
 	return &res
 }
@@ -112,6 +115,7 @@ type EADefinition struct {
 func NewEADefinition(eadef EADefinition) *EADefinition {
 	res := eadef
 	res.objectType = "extensibleattributedef"
+	res.returnFields = []string{"allowed_object_types", "comment", "flags", "list_values", "name", "type"}
 
 	return &res
 }


### PR DESCRIPTION
1) Added return_fields so that all fields supported by go objects are
returned by Infoblox.

2) Allow specifying Cidr when searching for fixed address in Infoblox.