### PR TITLE
Search EA's by passing in body instead of query string

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -183,35 +183,26 @@ func (wrb *WapiRequestBuilder) BuildUrl(t RequestType, objType string, ref strin
 }
 
 func (wrb *WapiRequestBuilder) BuildBody(t RequestType, obj IBObject) []byte {
-	var jsonStr []byte
+	var objJson []byte
 	var err error
 
-	jsonStr, err = json.Marshal(obj)
+	objJson, err = json.Marshal(obj)
 	if err != nil {
-		log.Printf("Cannot marshal payload: '%s'", obj)
+		log.Printf("Cannot marshal object '%s': %s", obj, err)
 		return nil
 	}
 
 	eaSearch := obj.EaSearch()
 	if t == GET && len(eaSearch) > 0 {
-		payload := make(map[string]string)
-		json.Unmarshal(jsonStr, &payload)
-		for k, v := range eaSearch {
-			str, ok := v.(string)
-			if !ok {
-				log.Printf("Cannot marshal EA Search attribute for '%s'\n", k)
-			} else {
-				payload["*"+k] = str
-			}
-		}
-		jsonStr, err = json.Marshal(payload)
+		eaSearchJson, err := json.Marshal(eaSearch)
 		if err != nil {
-			log.Printf("Cannot marshal EA's in the payload: '%s'", payload)
+			log.Printf("Cannot marshal EA Search attributes. '%s'\n", err)
 			return nil
 		}
+		objJson = append(append(objJson[:len(objJson)-1], []byte(",")...), eaSearchJson[1:]...)
 	}
 
-	return jsonStr
+	return objJson
 }
 
 func (wrb *WapiRequestBuilder) BuildRequest(t RequestType, obj IBObject, ref string) (req *http.Request, err error) {

--- a/connector.go
+++ b/connector.go
@@ -199,7 +199,7 @@ func (wrb *WapiRequestBuilder) BuildBody(t RequestType, obj IBObject) []byte {
 			log.Printf("Cannot marshal EA Search attributes. '%s'\n", err)
 			return nil
 		}
-		objJson = append(append(objJson[:len(objJson)-1], []byte(",")...), eaSearchJson[1:]...)
+		objJson = append(append(objJson[:len(objJson)-1], byte(',')), eaSearchJson[1:]...)
 	}
 
 	return objJson

--- a/connector.go
+++ b/connector.go
@@ -56,8 +56,8 @@ func NewTransportConfig(sslVerify string, httpRequestTimeout int, httpPoolConnec
 
 type HttpRequestBuilder interface {
 	Init(HostConfig)
-	BuildUrl(r RequestType, objType string, ref string, returnFields []string, eaSearch EA) (urlStr string)
-	BuildBody(obj IBObject) (jsonStr []byte)
+	BuildUrl(r RequestType, objType string, ref string, returnFields []string) (urlStr string)
+	BuildBody(r RequestType, obj IBObject) (jsonStr []byte)
 	BuildRequest(r RequestType, obj IBObject, ref string) (req *http.Request, err error)
 }
 
@@ -111,10 +111,12 @@ func (r RequestType) toMethod() string {
 	return ""
 }
 
-func logHttpResponse(resp *http.Response) {
+func getHttpResponseError(resp *http.Response) error {
 	defer resp.Body.Close()
 	content, _ := ioutil.ReadAll(resp.Body)
-	log.Printf("WAPI request error: %d('%s')\nContents:\n%s\n", resp.StatusCode, resp.Status, content)
+	msg := fmt.Sprintf("WAPI request error: %d('%s')\nContents:\n%s\n", resp.StatusCode, resp.Status, content)
+	log.Printf(msg)
+	return errors.New(msg)
 }
 
 func (whr *WapiHttpRequestor) Init(cfg TransportConfig) {
@@ -136,8 +138,8 @@ func (whr *WapiHttpRequestor) SendRequest(req *http.Request) (res []byte, err er
 	} else if !(resp.StatusCode == http.StatusOK ||
 		(resp.StatusCode == http.StatusCreated &&
 			req.Method == RequestType(CREATE).toMethod())) {
-		logHttpResponse(resp)
-		return
+		err := getHttpResponseError(resp)
+		return nil, err
 	}
 	defer resp.Body.Close()
 	res, err = ioutil.ReadAll(resp.Body)
@@ -153,7 +155,7 @@ func (wrb *WapiRequestBuilder) Init(cfg HostConfig) {
 	wrb.HostConfig = cfg
 }
 
-func (wrb *WapiRequestBuilder) BuildUrl(t RequestType, objType string, ref string, returnFields []string, eaSearch EA) (urlStr string) {
+func (wrb *WapiRequestBuilder) BuildUrl(t RequestType, objType string, ref string, returnFields []string) (urlStr string) {
 	path := []string{"wapi", "v" + wrb.HostConfig.Version}
 	if len(ref) > 0 {
 		path = append(path, ref)
@@ -167,18 +169,6 @@ func (wrb *WapiRequestBuilder) BuildUrl(t RequestType, objType string, ref strin
 		if len(returnFields) > 0 {
 			vals.Set("_return_fields", strings.Join(returnFields, ","))
 		}
-
-		if len(eaSearch) > 0 {
-			for k, v := range eaSearch {
-				str, ok := v.(string)
-				if !ok {
-					log.Printf("Cannot marshal EA Search attribute for '%s'\n", k)
-				} else {
-					vals.Set("*"+k, str)
-				}
-			}
-		}
-
 		qry = vals.Encode()
 	}
 
@@ -192,7 +182,7 @@ func (wrb *WapiRequestBuilder) BuildUrl(t RequestType, objType string, ref strin
 	return u.String()
 }
 
-func (wrb *WapiRequestBuilder) BuildBody(obj IBObject) []byte {
+func (wrb *WapiRequestBuilder) BuildBody(t RequestType, obj IBObject) []byte {
 	var jsonStr []byte
 	var err error
 
@@ -202,6 +192,25 @@ func (wrb *WapiRequestBuilder) BuildBody(obj IBObject) []byte {
 		return nil
 	}
 
+        eaSearch := obj.EaSearch()
+	if t == GET && len(eaSearch) > 0 {
+		payload := make(map[string]string)
+		json.Unmarshal(jsonStr, &payload)
+		for k, v := range eaSearch {
+			str, ok := v.(string)
+			if !ok {
+				log.Printf("Cannot marshal EA Search attribute for '%s'\n", k)
+			} else {
+				payload["*"+k] = str
+			}
+		}
+		jsonStr, err = json.Marshal(payload)
+		if err != nil {
+			log.Printf("Cannot marshal EA's in the payload: '%s'", payload)
+			return nil
+		}
+	}
+
 	return jsonStr
 }
 
@@ -209,18 +218,16 @@ func (wrb *WapiRequestBuilder) BuildRequest(t RequestType, obj IBObject, ref str
 	var (
 		objType      string
 		returnFields []string
-		eaSearch     EA
 	)
 	if obj != nil {
 		objType = obj.ObjectType()
 		returnFields = obj.ReturnFields()
-		eaSearch = obj.EaSearch()
 	}
-	urlStr := wrb.BuildUrl(t, objType, ref, returnFields, eaSearch)
+	urlStr := wrb.BuildUrl(t, objType, ref, returnFields)
 
 	var bodyStr []byte
 	if obj != nil {
-		bodyStr = wrb.BuildBody(obj)
+		bodyStr = wrb.BuildBody(t, obj)
 	}
 
 	req, err = http.NewRequest(t.toMethod(), urlStr, bytes.NewBuffer(bodyStr))

--- a/connector_test.go
+++ b/connector_test.go
@@ -142,7 +142,7 @@ var _ = Describe("Connector", func() {
 				cidr := "172.22.18.0/24"
 				eaKey := "Network Name"
 				eaVal := "yellow-net"
-				eaSearch := EAS{eaKey: eaVal}
+				eaSearch := EASearch{eaKey: eaVal}
 				nw := NewNetwork(Network{NetviewName: networkView, Cidr: cidr})
 				nw.eaSearch = eaSearch
 

--- a/connector_test.go
+++ b/connector_test.go
@@ -142,14 +142,14 @@ var _ = Describe("Connector", func() {
 				cidr := "172.22.18.0/24"
 				eaKey := "Network Name"
 				eaVal := "yellow-net"
-				eaSearch := EA{eaKey: eaVal}
+				eaSearch := EAS{eaKey: eaVal}
 				nw := NewNetwork(Network{NetviewName: networkView, Cidr: cidr})
 				nw.eaSearch = eaSearch
 
 				netviewStr := `"network_view":"` + networkView + `"`
 				networkStr := `"network":"` + cidr + `"`
 				eaSearchStr := `"*` + eaKey + `":"` + eaVal + `"`
-				expectedBodyStr := "{" + strings.Join([]string{eaSearchStr, networkStr, netviewStr}, ",") + "}"
+				expectedBodyStr := "{" + strings.Join([]string{netviewStr, networkStr, eaSearchStr}, ",") + "}"
 				bodyStr := wrb.BuildBody(GET, nw)
 
 				Expect(string(bodyStr)).To(Equal(expectedBodyStr))

--- a/object_manager.go
+++ b/object_manager.go
@@ -95,6 +95,9 @@ func (objMgr *ObjectManager) CreateNetwork(netview string, cidr string, name str
 		network.Ea["Network Name"] = name
 	}
 	ref, err := objMgr.connector.CreateObject(network)
+	if err != nil {
+		return nil, err
+	}
 	network.Ref = ref
 
 	return network, err

--- a/object_manager.go
+++ b/object_manager.go
@@ -160,7 +160,7 @@ func BuildNetworkFromRef(ref string) *Network {
 	}
 }
 
-func (objMgr *ObjectManager) GetNetwork(netview string, cidr string, eaSearch EASearch) (*Network, error) {
+func (objMgr *ObjectManager) GetNetwork(netview string, cidr string, ea EA) (*Network, error) {
 	var res []Network
 
 	network := NewNetwork(Network{
@@ -170,8 +170,8 @@ func (objMgr *ObjectManager) GetNetwork(netview string, cidr string, eaSearch EA
 		network.Cidr = cidr
 	}
 
-	if eaSearch != nil && len(eaSearch) > 0 {
-		network.eaSearch = eaSearch
+	if ea != nil && len(ea) > 0 {
+		network.eaSearch = EASearch(ea)
 	}
 
 	err := objMgr.connector.GetObject(network, "", &res)

--- a/object_manager.go
+++ b/object_manager.go
@@ -160,7 +160,7 @@ func BuildNetworkFromRef(ref string) *Network {
 	}
 }
 
-func (objMgr *ObjectManager) GetNetwork(netview string, cidr string, eaSearch EAS) (*Network, error) {
+func (objMgr *ObjectManager) GetNetwork(netview string, cidr string, eaSearch EASearch) (*Network, error) {
 	var res []Network
 
 	network := NewNetwork(Network{

--- a/object_manager.go
+++ b/object_manager.go
@@ -160,7 +160,7 @@ func BuildNetworkFromRef(ref string) *Network {
 	}
 }
 
-func (objMgr *ObjectManager) GetNetwork(netview string, cidr string, ea EA) (*Network, error) {
+func (objMgr *ObjectManager) GetNetwork(netview string, cidr string, eaSearch EAS) (*Network, error) {
 	var res []Network
 
 	network := NewNetwork(Network{
@@ -170,8 +170,8 @@ func (objMgr *ObjectManager) GetNetwork(netview string, cidr string, ea EA) (*Ne
 		network.Cidr = cidr
 	}
 
-	if ea != nil && len(ea) > 0 {
-		network.eaSearch = ea
+	if eaSearch != nil && len(eaSearch) > 0 {
+		network.eaSearch = eaSearch
 	}
 
 	err := objMgr.connector.GetObject(network, "", &res)

--- a/object_manager_test.go
+++ b/object_manager_test.go
@@ -358,7 +358,7 @@ var _ = Describe("Object Manager", func() {
 		netviewName := "default_view"
 		cidr := "28.0.42.0/24"
 		networkName := "private-net"
-		ea := EA{"Network Name": networkName}
+		eaSearch := EAS{"Network Name": networkName}
 		fakeRefReturn := fmt.Sprintf("network/ZG5zLm5ldHdvcmskODkuMC4wLjAvMjQvMjU:%s/%s", cidr, netviewName)
 		nwFakeConnector := &fakeConnector{
 			getObjectObj: NewNetwork(Network{NetviewName: netviewName, Cidr: cidr}),
@@ -366,15 +366,15 @@ var _ = Describe("Object Manager", func() {
 			resultObject: []Network{*NewNetwork(Network{NetviewName: netviewName, Cidr: cidr, Ref: fakeRefReturn})},
 		}
 
-		nwFakeConnector.getObjectObj.(*Network).eaSearch = ea
-		nwFakeConnector.resultObject.([]Network)[0].eaSearch = ea
+		nwFakeConnector.getObjectObj.(*Network).eaSearch = eaSearch
+		nwFakeConnector.resultObject.([]Network)[0].eaSearch = eaSearch
 
 		objMgr := NewObjectManager(nwFakeConnector, cmpType, tenantID)
 
 		var actualNetwork *Network
 		var err error
 		It("should pass expected Network Object to GetObject", func() {
-			actualNetwork, err = objMgr.GetNetwork(netviewName, cidr, ea)
+			actualNetwork, err = objMgr.GetNetwork(netviewName, cidr, eaSearch)
 		})
 		It("should return expected Network Object", func() {
 			Expect(*actualNetwork).To(Equal(nwFakeConnector.resultObject.([]Network)[0]))

--- a/object_manager_test.go
+++ b/object_manager_test.go
@@ -358,7 +358,7 @@ var _ = Describe("Object Manager", func() {
 		netviewName := "default_view"
 		cidr := "28.0.42.0/24"
 		networkName := "private-net"
-		eaSearch := EAS{"Network Name": networkName}
+		eaSearch := EASearch{"Network Name": networkName}
 		fakeRefReturn := fmt.Sprintf("network/ZG5zLm5ldHdvcmskODkuMC4wLjAvMjQvMjU:%s/%s", cidr, netviewName)
 		nwFakeConnector := &fakeConnector{
 			getObjectObj: NewNetwork(Network{NetviewName: netviewName, Cidr: cidr}),

--- a/object_manager_test.go
+++ b/object_manager_test.go
@@ -358,7 +358,7 @@ var _ = Describe("Object Manager", func() {
 		netviewName := "default_view"
 		cidr := "28.0.42.0/24"
 		networkName := "private-net"
-		eaSearch := EASearch{"Network Name": networkName}
+		ea := EA{"Network Name": networkName}
 		fakeRefReturn := fmt.Sprintf("network/ZG5zLm5ldHdvcmskODkuMC4wLjAvMjQvMjU:%s/%s", cidr, netviewName)
 		nwFakeConnector := &fakeConnector{
 			getObjectObj: NewNetwork(Network{NetviewName: netviewName, Cidr: cidr}),
@@ -366,15 +366,15 @@ var _ = Describe("Object Manager", func() {
 			resultObject: []Network{*NewNetwork(Network{NetviewName: netviewName, Cidr: cidr, Ref: fakeRefReturn})},
 		}
 
-		nwFakeConnector.getObjectObj.(*Network).eaSearch = eaSearch
-		nwFakeConnector.resultObject.([]Network)[0].eaSearch = eaSearch
+		nwFakeConnector.getObjectObj.(*Network).eaSearch = EASearch(ea)
+		nwFakeConnector.resultObject.([]Network)[0].eaSearch = EASearch(ea)
 
 		objMgr := NewObjectManager(nwFakeConnector, cmpType, tenantID)
 
 		var actualNetwork *Network
 		var err error
 		It("should pass expected Network Object to GetObject", func() {
-			actualNetwork, err = objMgr.GetNetwork(netviewName, cidr, eaSearch)
+			actualNetwork, err = objMgr.GetNetwork(netviewName, cidr, ea)
 		})
 		It("should return expected Network Object", func() {
 			Expect(*actualNetwork).To(Equal(nwFakeConnector.resultObject.([]Network)[0]))

--- a/objects.go
+++ b/objects.go
@@ -11,19 +11,20 @@ const MACADDR_ZERO = "00:00:00:00:00:00"
 type Bool bool
 
 type EA map[string]interface{}
+type EAS map[string]interface{}
 
 type EADefListValue string
 
 type IBBase struct {
 	objectType   string   `json:"-"`
 	returnFields []string `json:"-"`
-	eaSearch     EA       `json:"-"`
+	eaSearch     EAS      `json:"-"`
 }
 
 type IBObject interface {
 	ObjectType() string
 	ReturnFields() []string
-	EaSearch() EA
+	EaSearch() EAS
 }
 
 func (obj *IBBase) ObjectType() string {
@@ -34,7 +35,7 @@ func (obj *IBBase) ReturnFields() []string {
 	return obj.returnFields
 }
 
-func (obj *IBBase) EaSearch() EA {
+func (obj *IBBase) EaSearch() EAS {
 	return obj.eaSearch
 }
 
@@ -128,6 +129,15 @@ func (ea EA) MarshalJSON() ([]byte, error) {
 		value := make(map[string]interface{})
 		value["value"] = v
 		m[k] = value
+	}
+
+	return json.Marshal(m)
+}
+
+func (eas EAS) MarshalJSON() ([]byte, error) {
+	m := make(map[string]interface{})
+	for k, v := range eas {
+		m["*"+k] = v
 	}
 
 	return json.Marshal(m)

--- a/objects.go
+++ b/objects.go
@@ -11,20 +11,21 @@ const MACADDR_ZERO = "00:00:00:00:00:00"
 type Bool bool
 
 type EA map[string]interface{}
-type EAS map[string]interface{}
+
+type EASearch map[string]interface{}
 
 type EADefListValue string
 
 type IBBase struct {
 	objectType   string   `json:"-"`
 	returnFields []string `json:"-"`
-	eaSearch     EAS      `json:"-"`
+	eaSearch     EASearch `json:"-"`
 }
 
 type IBObject interface {
 	ObjectType() string
 	ReturnFields() []string
-	EaSearch() EAS
+	EaSearch() EASearch
 }
 
 func (obj *IBBase) ObjectType() string {
@@ -35,7 +36,7 @@ func (obj *IBBase) ReturnFields() []string {
 	return obj.returnFields
 }
 
-func (obj *IBBase) EaSearch() EAS {
+func (obj *IBBase) EaSearch() EASearch {
 	return obj.eaSearch
 }
 
@@ -134,7 +135,7 @@ func (ea EA) MarshalJSON() ([]byte, error) {
 	return json.Marshal(m)
 }
 
-func (eas EAS) MarshalJSON() ([]byte, error) {
+func (eas EASearch) MarshalJSON() ([]byte, error) {
 	m := make(map[string]interface{})
 	for k, v := range eas {
 		m["*"+k] = v

--- a/objects_test.go
+++ b/objects_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Objects", func() {
 	})
 
 	Context("EA Search Object", func() {
-		eas := EAS{
+		eas := EASearch{
 			"Network Name": "Shared-Net",
 			"Network View": "Global",
 		}
@@ -131,7 +131,7 @@ var _ = Describe("Objects", func() {
 			cidr := "123.0.0.0/24"
 			netviewName := "localview"
 			nw := NewNetwork(Network{Cidr: cidr, NetviewName: netviewName})
-			searchEAs := EAS{"Network Name": "shared-net"}
+			searchEAs := EASearch{"Network Name": "shared-net"}
 			nw.eaSearch = searchEAs
 
 			It("should set fields correctly", func() {

--- a/objects_test.go
+++ b/objects_test.go
@@ -53,6 +53,29 @@ var _ = Describe("Objects", func() {
 
 	})
 
+	Context("EA Search Object", func() {
+		eas := EAS{
+			"Network Name": "Shared-Net",
+			"Network View": "Global",
+		}
+		expectedJSON := `{"*Network Name" :"Shared-Net",` +
+			`"*Network View" :"Global"}`
+
+		Context("Marshalling", func() {
+			Context("expected JSON is returned", func() {
+				js, err := json.Marshal(eas)
+
+				It("should not error", func() {
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				It("should match json expected", func() {
+					Expect(js).To(MatchJSON(expectedJSON))
+				})
+			})
+		})
+	})
+
 	Context("EADefListValue Object", func() {
 		var eadListVal EADefListValue = "Host Record"
 
@@ -108,7 +131,7 @@ var _ = Describe("Objects", func() {
 			cidr := "123.0.0.0/24"
 			netviewName := "localview"
 			nw := NewNetwork(Network{Cidr: cidr, NetviewName: netviewName})
-			searchEAs := EA{"Network Name": "shared-net"}
+			searchEAs := EAS{"Network Name": "shared-net"}
 			nw.eaSearch = searchEAs
 
 			It("should set fields correctly", func() {
@@ -195,7 +218,7 @@ var _ = Describe("Objects", func() {
 
 	})
 
-	Context("Umnarshalling malformed JSON", func() {
+	Context("Unmarshalling malformed JSON", func() {
 		Context("for EA", func() {
 			badJSON := `""`
 			var ea EA


### PR DESCRIPTION
This patch passes EA's in body instead of query string because of
the issue #18.
Also Fixes issues where error is not returned when there is error
in the request response body.