### PR TITLE
Added support for UpdateFixedAddress in client

### DIFF
--- a/object_manager.go
+++ b/object_manager.go
@@ -16,7 +16,7 @@ type IBObjectManager interface {
 	GetNetworkContainer(netview string, cidr string) (*NetworkContainer, error)
 	AllocateIP(netview string, cidr string, ipAddr string, macAddress string, vmID string) (*FixedAddress, error)
 	AllocateNetwork(netview string, cidr string, prefixLen uint, name string) (network *Network, err error)
-	UpdateFixedAddress(fixedAddr *FixedAddress, macAddress string, vmID string) (*FixedAddress, error)
+	UpdateFixedAddress(fixedAddrRef string, macAddress string, vmID string) (*FixedAddress, error)
 	GetFixedAddress(netview string, cidr string, ipAddr string, macAddr string) (*FixedAddress, error)
 	ReleaseIP(netview string, cidr string, ipAddr string, macAddr string) (string, error)
 	DeleteNetwork(ref string, netview string) (string, error)
@@ -309,21 +309,23 @@ func (objMgr *ObjectManager) GetFixedAddress(netview string, cidr string, ipAddr
 	return &res[0], nil
 }
 
-func (objMgr *ObjectManager) UpdateFixedAddress(fixedAddr *FixedAddress, macAddress string, vmID string) (*FixedAddress, error) {
+func (objMgr *ObjectManager) UpdateFixedAddress(fixedAddrRef string, macAddress string, vmID string) (*FixedAddress, error) {
+
+	updateFixedAddr := NewFixedAddress(FixedAddress{Ref: fixedAddrRef})
 
 	if len(macAddress) != 0 {
-		fixedAddr.Mac = macAddress
+		updateFixedAddr.Mac = macAddress
 	}
 
 	if vmID != "" {
 		ea := objMgr.getBasicEA(true)
 		ea["VM ID"] = vmID
-		fixedAddr.Ea = ea
+		updateFixedAddr.Ea = ea
 	}
 
-	refResp, err := objMgr.connector.UpdateObject(fixedAddr, fixedAddr.Ref)
-	fixedAddr.Ref = refResp
-	return fixedAddr, err
+	refResp, err := objMgr.connector.UpdateObject(updateFixedAddr, fixedAddrRef)
+	updateFixedAddr.Ref = refResp
+	return updateFixedAddr, err
 }
 
 func (objMgr *ObjectManager) ReleaseIP(netview string, cidr string, ipAddr string, macAddr string) (string, error) {

--- a/object_manager.go
+++ b/object_manager.go
@@ -16,6 +16,7 @@ type IBObjectManager interface {
 	GetNetworkContainer(netview string, cidr string) (*NetworkContainer, error)
 	AllocateIP(netview string, cidr string, ipAddr string, macAddress string, vmID string) (*FixedAddress, error)
 	AllocateNetwork(netview string, cidr string, prefixLen uint, name string) (network *Network, err error)
+	UpdateFixedAddress(netview string, cidr string, ipAddr string, macAddress string, vmID string) (*FixedAddress, error)
 	GetFixedAddress(netview string, cidr string, ipAddr string, macAddr string) (*FixedAddress, error)
 	ReleaseIP(netview string, cidr string, ipAddr string, macAddr string) (string, error)
 	DeleteNetwork(ref string, netview string) (string, error)
@@ -302,6 +303,40 @@ func (objMgr *ObjectManager) GetFixedAddress(netview string, cidr string, ipAddr
 	}
 
 	return &res[0], nil
+}
+
+func (objMgr *ObjectManager) UpdateFixedAddress(netview string, cidr string, ipAddr string, macAddress string, vmID string) (*FixedAddress, error) {
+
+        var res []FixedAddress
+        // Update is based on IP, CIDR and NETWORK VIEW
+        fixedAddr := NewFixedAddress(FixedAddress{
+                NetviewName: netview,
+                Cidr:        cidr,
+                IPAddress:   ipAddr})
+
+        err := objMgr.connector.GetObject(fixedAddr, "", &res)
+        if err != nil || res == nil || len(res) == 0 {
+                return nil, err
+        }
+        _fixedAddr := &res[0]
+
+	ea := objMgr.getBasicEA(true)
+	ea["VM ID"] = "N/A"
+	if vmID != "" {
+		ea["VM ID"] = vmID
+                _fixedAddr.Ea = ea
+	}
+
+
+	if len(macAddress) == 0 {
+		_fixedAddr.Mac = MACADDR_ZERO
+	} else {
+                _fixedAddr.Mac = macAddress
+        }
+
+	refResp, err := objMgr.connector.UpdateObject(_fixedAddr, _fixedAddr.Ref)
+        _fixedAddr.Ref = refResp
+	return _fixedAddr, err
 }
 
 func (objMgr *ObjectManager) ReleaseIP(netview string, cidr string, ipAddr string, macAddr string) (string, error) {


### PR DESCRIPTION
UpdateFixedAddress is required to support cni_spec 0.3.1 as with
cni release v0.4.0: https://github.com/containernetworking/cni/releases/tag/v0.4.0
The mac_address of the interface was allocated based on the ip_address on all the
network drivers, for example:
https://github.com/containernetworking/cni/blob/v0.4.0/plugins/main/macvlan/macvlan.go#L153