### PR TITLE
add objects required by Kubernetes external-dns provider

### DIFF
--- a/objects.go
+++ b/objects.go
@@ -138,6 +138,76 @@ func NewUserProfile(userprofile UserProfile) *UserProfile {
 	return &res
 }
 
+type RecordA struct {
+	IBBase   `json:"-"`
+	Ref      string `json:"_ref,omitempty"`
+	Ipv4Addr string `json:"ipv4addr,omitempty"`
+	Name     string `json:"name,omitempty"`
+	View     string `json:"view,omitempty"`
+	Zone     string `json:"zone,omitempty"`
+	Ea       EA     `json:"extattrs,omitempty"`
+}
+
+func NewRecordA(ra RecordA) *RecordA {
+	res := ra
+	res.objectType = "record:a"
+	res.returnFields = []string{"extattrs", "ipv4addr", "name", "view", "zone"}
+
+	return &res
+}
+
+type RecordCNAME struct {
+	IBBase    `json:"-"`
+	Ref       string `json:"_ref,omitempty"`
+	Canonical string `json:"canonical,omitempty"`
+	Name      string `json:"name,omitempty"`
+	View      string `json:"view,omitempty"`
+	Zone      string `json:"zone,omitempty"`
+	Ea        EA     `json:"extattrs,omitempty"`
+}
+
+func NewRecordCNAME(rc RecordCNAME) *RecordCNAME {
+	res := rc
+	res.objectType = "record:cname"
+	res.returnFields = []string{"extattrs", "canonical", "name", "view", "zone"}
+
+	return &res
+}
+
+type RecordTXT struct {
+	IBBase `json:"-"`
+	Ref    string `json:"_ref,omitempty"`
+	Name   string `json:"name,omitempty"`
+	Text   string `json:"text,omitempty"`
+	View   string `json:"view,omitempty"`
+	Zone   string `json:"zone,omitempty"`
+	Ea     EA     `json:"extattrs,omitempty"`
+}
+
+func NewRecordTXT(rt RecordTXT) *RecordTXT {
+	res := rt
+	res.objectType = "record:txt"
+	res.returnFields = []string{"extattrs", "name", "text", "view", "zone"}
+
+	return &res
+}
+
+type ZoneAuth struct {
+	IBBase `json:"-"`
+	Ref    string `json:"_ref,omitempty"`
+	Fqdn   string `json:"fqdn,omitempty"`
+	View   string `json:"view,omitempty"`
+	Ea     EA     `json:"extattrs,omitempty"`
+}
+
+func NewZoneAuth(za ZoneAuth) *ZoneAuth {
+	res := za
+	res.objectType = "zone_auth"
+	res.returnFields = []string{"extattrs", "fqdn", "view"}
+
+	return &res
+}
+
 func (ea EA) MarshalJSON() ([]byte, error) {
 	m := make(map[string]interface{})
 	for k, v := range ea {

--- a/objects_test.go
+++ b/objects_test.go
@@ -216,6 +216,100 @@ var _ = Describe("Objects", func() {
 			})
 		})
 
+		Context("RecordA object", func() {
+			ipv4addr := "1.1.1.1"
+			name := "bind_a.domain.com"
+			view := "default"
+			zone := "domain.com"
+
+			ra := NewRecordA(RecordA{
+				Ipv4Addr: ipv4addr,
+				Name:     name,
+				View:     view,
+				Zone:     zone})
+
+			It("should set fields correctly", func() {
+				Expect(ra.Ipv4Addr).To(Equal(ipv4addr))
+				Expect(ra.Name).To(Equal(name))
+				Expect(ra.View).To(Equal(view))
+				Expect(ra.Zone).To(Equal(zone))
+			})
+
+			It("should set base fields correctly", func() {
+				Expect(ra.ObjectType()).To(Equal("record:a"))
+				Expect(ra.ReturnFields()).To(ConsistOf("extattrs", "ipv4addr", "name", "view", "zone"))
+			})
+		})
+
+		Context("RecordCNAME object", func() {
+			canonical := "cname.domain.com"
+			name := "bind_cname.domain.com"
+			view := "default"
+			zone := "domain.com"
+
+			rc := NewRecordCNAME(RecordCNAME{
+				Canonical: canonical,
+				Name:      name,
+				View:      view,
+				Zone:      zone})
+
+			It("should set fields correctly", func() {
+				Expect(rc.Canonical).To(Equal(canonical))
+				Expect(rc.Name).To(Equal(name))
+				Expect(rc.View).To(Equal(view))
+				Expect(rc.Zone).To(Equal(zone))
+			})
+
+			It("should set base fields correctly", func() {
+				Expect(rc.ObjectType()).To(Equal("record:cname"))
+				Expect(rc.ReturnFields()).To(ConsistOf("extattrs", "canonical", "name", "view", "zone"))
+			})
+		})
+
+		Context("RecordTXT object", func() {
+			name := "txt.domain.com"
+			text := "this is text string"
+			view := "default"
+			zone := "domain.com"
+
+			rt := NewRecordTXT(RecordTXT{
+				Name: name,
+				Text: text,
+				View: view,
+				Zone: zone})
+
+			It("should set fields correctly", func() {
+				Expect(rt.Name).To(Equal(name))
+				Expect(rt.Text).To(Equal(text))
+				Expect(rt.View).To(Equal(view))
+				Expect(rt.Zone).To(Equal(zone))
+			})
+
+			It("should set base fields correctly", func() {
+				Expect(rt.ObjectType()).To(Equal("record:txt"))
+				Expect(rt.ReturnFields()).To(ConsistOf("extattrs", "name", "text", "view", "zone"))
+			})
+		})
+
+		Context("ZoneAuth object", func() {
+			fqdn := "domain.com"
+			view := "default"
+
+			za := NewZoneAuth(ZoneAuth{
+				Fqdn: fqdn,
+				View: view})
+
+			It("should set fields correctly", func() {
+				Expect(za.Fqdn).To(Equal(fqdn))
+				Expect(za.View).To(Equal(view))
+			})
+
+			It("should set base fields correctly", func() {
+				Expect(za.ObjectType()).To(Equal("zone_auth"))
+				Expect(za.ReturnFields()).To(ConsistOf("extattrs", "fqdn", "view"))
+			})
+		})
+
 	})
 
 	Context("Unmarshalling malformed JSON", func() {


### PR DESCRIPTION
Neither the infobloxopen/infoblox-go-client:master nor the khris.richardson/infoblox-go-client:k8s-external-dns-provider passed for me, but I tried to remain consistent with the other unit tests.

The AllRecords test is commented out, since I suspect it may not pass given that it's a read-only object.