### PR TITLE
add support for record:host

### DIFF
--- a/objects.go
+++ b/objects.go
@@ -174,6 +174,29 @@ func NewRecordCNAME(rc RecordCNAME) *RecordCNAME {
 	return &res
 }
 
+type RecordHostIpv4Addr struct {
+	Ipv4Addr string `json:"ipv4addr,omitempty"`
+}
+
+type RecordHost struct {
+	IBBase    `json:"-"`
+	Ref       string               `json:"_ref,omitempty"`
+	Ipv4Addr  string               `json:"ipv4addr,omitempty"`
+	Ipv4Addrs []RecordHostIpv4Addr `json:"ipv4addrs,omitempty"`
+	Name      string               `json:"name,omitempty"`
+	View      string               `json:"view,omitempty"`
+	Zone      string               `json:"zone,omitempty"`
+	Ea        EA                   `json:"extattrs,omitempty"`
+}
+
+func NewRecordHost(rh RecordHost) *RecordHost {
+	res := rh
+	res.objectType = "record:host"
+	res.returnFields = []string{"extattrs", "ipv4addrs", "name", "view", "zone"}
+
+	return &res
+}
+
 type RecordTXT struct {
 	IBBase `json:"-"`
 	Ref    string `json:"_ref,omitempty"`

--- a/objects_test.go
+++ b/objects_test.go
@@ -275,6 +275,31 @@ var _ = Describe("Objects", func() {
 			})
 		})
 
+		Context("RecordHost object", func() {
+			ipv4addrs := []RecordHostIpv4Addr{{Ipv4Addr: "1.1.1.1"}, {Ipv4Addr: "2.2.2.2"}}
+			name := "bind_host.domain.com"
+			view := "default"
+			zone := "domain.com"
+
+			rh := NewRecordHost(RecordHost{
+				Ipv4Addrs: ipv4addrs,
+				Name:      name,
+				View:      view,
+				Zone:      zone})
+
+			It("should set fields correctly", func() {
+				Expect(rh.Ipv4Addrs).To(Equal(ipv4addrs))
+				Expect(rh.Name).To(Equal(name))
+				Expect(rh.View).To(Equal(view))
+				Expect(rh.Zone).To(Equal(zone))
+			})
+
+			It("should set base fields correctly", func() {
+				Expect(rh.ObjectType()).To(Equal("record:host"))
+				Expect(rh.ReturnFields()).To(ConsistOf("extattrs", "ipv4addrs", "name", "view", "zone"))
+			})
+		})
+
 		Context("RecordTXT object", func() {
 			name := "txt.domain.com"
 			text := "this is text string"


### PR DESCRIPTION
This PR will facilitate preventing the Infoblox external-dns provider for Kubernetes (WIP) from creating an `A` record if a corresponding `Host` record already exists.