### PR TITLE
Replace hardcoded 1000000000 with time.Second.

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -26,7 +26,7 @@ type HostConfig struct {
 type TransportConfig struct {
 	SslVerify           bool
 	certPool            *x509.CertPool
-	HttpRequestTimeout  int // in seconds
+	HttpRequestTimeout  time.Duration // in seconds
 	HttpPoolConnections int
 }
 
@@ -127,7 +127,7 @@ func (whr *WapiHttpRequestor) Init(cfg TransportConfig) {
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: !cfg.SslVerify,
 			RootCAs: cfg.certPool},
 		MaxIdleConnsPerHost:   cfg.HttpPoolConnections,
-		ResponseHeaderTimeout: time.Duration(cfg.HttpRequestTimeout * 1000000000), // ResponseHeaderTimeout is in nanoseconds
+		ResponseHeaderTimeout: cfg.HttpRequestTimeout * time.Second,
 	}
 
 	whr.client = http.Client{Transport: tr}

--- a/connector.go
+++ b/connector.go
@@ -52,7 +52,7 @@ func NewTransportConfig(sslVerify string, httpRequestTimeout int, httpPoolConnec
 	}
 
 	cfg.HttpPoolConnections = httpPoolConnections
-	cfg.HttpRequestTimeout = httpRequestTimeout
+	cfg.HttpRequestTimeout = time.Duration(httpRequestTimeout)
 	return
 }
 


### PR DESCRIPTION
While here declare HttpRequestTimeout as a time.Duration so there is no
need for a type conversion.