### PR TITLE
Support login session using ibapauth cookie.

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -322,6 +322,15 @@ func (c *Connector) UpdateObject(obj IBObject, ref string) (refRes string, err e
 	return
 }
 
+func (c *Connector) Logout() (err error) {
+	_, err = c.makeRequest(CREATE, nil, "logout")
+	if err != nil {
+		log.Printf("Logout request error: '%s'\n", err)
+	}
+
+	return
+}
+
 var ValidateConnector = validateConnector
 
 func validateConnector(c *Connector) (err error) {
@@ -353,14 +362,5 @@ func NewConnector(hostConfig HostConfig, transportConfig TransportConfig,
 
 	res = connector
 	err = ValidateConnector(connector)
-	return
-}
-
-func (c *Connector) Logout() (err error) {
-	_, err = c.makeRequest(CREATE, nil, "logout")
-	if err != nil {
-		log.Printf("Logout request error: '%s'\n", err)
-	}
-
 	return
 }


### PR DESCRIPTION
This makes multiple requests use the same login session instead of
creating one login event per request.

A Logout() method is added to the *Connector so you can invalidate the
cookie when you are done, for example using a defer statement.

Below is an example code snippet  used when testing this. Before the change there will be two login events in the audit log, even if I only perform one request (becase of validateConnector() performing an initial request). After the change only a single login event is logged, and the newly added conn.Logout() will lead to an logout event in the audit log:

```
package main

import (
        "fmt"
        ibclient "github.com/infobloxopen/infoblox-go-client"
        "log"
)

func main() {
        hostConfig := ibclient.HostConfig{
                Host:     "ipam.example.com",
                Version:  "x.x.x",
                Port:     "443",
                Username: "user",
                Password: "password",
        }

        transportConfig := ibclient.NewTransportConfig(
                "true",
                60,
                10,
        )

        requestBuilder := &ibclient.WapiRequestBuilder{}
        requestor := &ibclient.WapiHttpRequestor{}

        conn, err := ibclient.NewConnector(
                hostConfig,
                transportConfig,
                requestBuilder,
                requestor,
        )

        if err != nil {
                log.Fatal(err)
        }

        // New functionality
        defer conn.Logout()

        var result []ibclient.RecordA

        recordAObj := ibclient.NewRecordA(ibclient.RecordA{
                Ipv4Addr: "127.0.0.1",
        })

        err = conn.GetObject(recordAObj, "", &result)

        if err != nil {
                log.Fatal(err)
        }

        for _, recordA := range result {
                fmt.Println(recordA.Ref)
        }
}
```