### PR TITLE
Add readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,67 @@
+# Infoblox Go Client
+
+An Infoblox Client library for Go.
+
+This library is compatible with Go 1.2+
+
+- [Prerequisites](#Prerequisites)
+- [Installation](#Installation)
+- [Usage](#Usage)
+
+## Prerequisites
+   * Infoblox GRID with 2.5 or above WAPI support
+   * Go 1.2 or above
+
+## Installation
+   go get github.com/infobloxopen/infoblox-go-client
+
+## Usage
+
+   The following is a very simple example for the client usage:
+
+       package main
+       import (
+   	    "fmt"
+   	    ibclient "github.com/infobloxopen/infoblox-go-client"
+       )
+
+       func main() {
+   	    hostConfig := ibclient.HostConfig{
+   		    Host:     "10.196.107.209",
+   		    Version:  "2.8",
+   		    Port:     "443",
+   		    Username: "admin",
+   		    Password: "infoblox",
+   	    }
+   	    transportConfig := ibclient.NewTransportConfig("false", 20, 10)
+   	    requestBuilder := &ibclient.WapiRequestBuilder{}
+   	    requestor := &ibclient.WapiHttpRequestor{}
+   	    conn, err := ibclient.NewConnector(hostConfig, transportConfig, requestBuilder, requestor)
+   	    if err != nil {
+   		    fmt.Println(err)
+   	    }
+   	    objMgr := ibclient.NewObjectManager(conn, "myclient", "")
+   	    //Fetches grid information
+   	    fmt.Println(objMgr.GetLicense())
+       }
+
+## Supported NIOS operations
+
+   * CreateNetworkView
+   * CreateDefaultNetviews
+   * CreateNetwork
+   * CreateNetworkContainer
+   * GetNetworkView
+   * GetNetwork
+   * GetNetworkContainer
+   * AllocateNetwork
+   * UpdateFixedAddress
+   * GetFixedAddress
+   * ReleaseIP
+   * DeleteNetwork
+   * GetEADefinition
+   * CreateEADefinition
+   * UpdateNetworkViewEA
+   * GetCapacityReport
+   * GetAllMembers
+   * GetUpgradeStatus (2.7 or above)

--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ This library is compatible with Go 1.2+
 
        func main() {
    	    hostConfig := ibclient.HostConfig{
-   		    Host:     "10.196.107.209",
-   		    Version:  "2.8",
-   		    Port:     "443",
-   		    Username: "admin",
-   		    Password: "infoblox",
+   		    Host:     "<NIOS grid IP>",
+   		    Version:  "<WAPI version>",
+   		    Port:     "PORT",
+   		    Username: "username",
+   		    Password: "password",
    	    }
    	    transportConfig := ibclient.NewTransportConfig("false", 20, 10)
    	    requestBuilder := &ibclient.WapiRequestBuilder{}

--- a/connector.go
+++ b/connector.go
@@ -51,6 +51,8 @@ func NewTransportConfig(sslVerify string, httpRequestTimeout int, httpPoolConnec
 		cfg.SslVerify = true
 	}
 
+	cfg.HttpPoolConnections = httpPoolConnections
+	cfg.HttpRequestTimeout = httpRequestTimeout
 	return
 }
 


### PR DESCRIPTION
* Long overdue readme file for the client
* set httpRequestTimeout & httpPoolConnections while creating TransportConfig

  Currently NewTransportConfig takes an "httpRequestTimeout int" but it is not
  used to fill in the returned "cfg TransportConfig", which is wrong. Fixing the
  issue in this patch