### PR TITLE
object_manager.go: Fix internal golint suggestions

### DIFF
--- a/object_manager.go
+++ b/object_manager.go
@@ -42,9 +42,9 @@ func NewObjectManager(connector IBConnector, cmpType string, tenantID string) *O
 	return objMgr
 }
 
-func (objMgr *ObjectManager) getBasicEA(cloudApiOwned Bool) EA {
+func (objMgr *ObjectManager) getBasicEA(cloudAPIOwned Bool) EA {
 	ea := make(EA)
-	ea["Cloud API Owned"] = cloudApiOwned
+	ea["Cloud API Owned"] = cloudAPIOwned
 	ea["CMP Type"] = objMgr.cmpType
 	ea["Tenant ID"] = objMgr.tenantID
 	return ea
@@ -148,7 +148,7 @@ func (objMgr *ObjectManager) UpdateNetworkViewEA(ref string, addEA EA, removeEA 
 		res.Ea[k] = v
 	}
 
-	for k, _ := range removeEA {
+	for k := range removeEA {
 		_, ok := res.Ea[k]
 		if ok {
 			delete(res.Ea, k)


### PR DESCRIPTION
Fixes:
```
object_manager.go:45:41: method parameter cloudApiOwned should be cloudAPIOwned
object_manager.go:151:9: should omit 2nd value from range; this loop is equivalent to `for k := range ...`
```

Chipping away at #41.