### PR TITLE
objects.go: Fix internal golint suggestions.

### DIFF
--- a/objects.go
+++ b/objects.go
@@ -456,9 +456,9 @@ func (eas EASearch) MarshalJSON() ([]byte, error) {
 	return json.Marshal(m)
 }
 
-func (val EADefListValue) MarshalJSON() ([]byte, error) {
+func (v EADefListValue) MarshalJSON() ([]byte, error) {
 	m := make(map[string]string)
-	m["value"] = string(val)
+	m["value"] = string(v)
 
 	return json.Marshal(m)
 }


### PR DESCRIPTION
Fixes:
```
objects.go:503:1: receiver name v should be consistent with previous receiver name val for EADefListValue
```

Chipping away at #41.