### PR TITLE
Moving the EA filter query to request URL instead of building it on t…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ _testmain.go
 *.exe
 *.test
 *.prof
+*.coverage

--- a/object_manager.go
+++ b/object_manager.go
@@ -451,3 +451,16 @@ func (objMgr *ObjectManager) GetGridInfo() ([]Grid, error) {
 	err := objMgr.connector.GetObject(gridObj, "", &res)
 	return res, err
 }
+
+// GetRecordA returns all the A-records
+func (objMgr *ObjectManager) GetRecordA(ea EA) ([]RecordA, error) {
+	var res []RecordA
+
+	recordA := NewRecordA(RecordA{})
+	if ea != nil && len(ea) > 0 {
+		recordA.eaSearch = EASearch(ea)
+	}
+
+	err := objMgr.connector.GetObject(recordA, "", &res)
+	return res, err
+}


### PR DESCRIPTION
…he payload body

    * Currently the EA filters are passed as api payload, this is creating
      problem when the obj is empty and ea is requested in GET call. Hence
      moving it as URL parameter.

      `objJSON = append(append(objJSON[:len(objJSON)-1], byte(',')), eaSearchJSON[1:]...)`
      The above objJSON fails to get unmarshalled when objJSON is not having any payload apart from easearch.  Empty check becomes tedious for the generic obj.  

    * Add Get A record call