### PR TITLE
Moving the EA filter query to request URL instead of building it on t…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ _testmain.go
 *.exe
 *.test
 *.prof
+*.coverage

--- a/connector.go
+++ b/connector.go
@@ -266,6 +266,7 @@ func (c *Connector) CreateObject(obj IBObject) (ref string, err error) {
 }
 
 func (c *Connector) GetObject(obj IBObject, ref string, res interface{}) (err error) {
+
 	resp, err := c.makeRequest(GET, obj, ref)
 	if err != nil {
 		log.Printf("GetObject request error: '%s'\n", err)

--- a/object_manager.go
+++ b/object_manager.go
@@ -196,12 +196,12 @@ func (objMgr *ObjectManager) GetNetwork(netview string, cidr string, ea EA) (*Ne
 	network := NewNetwork(Network{
 		NetviewName: netview})
 
+	if ea != nil && len(ea) > 0 {
+        network.eaSearch = EASearch(ea)
+    }
+
 	if cidr != "" {
 		network.Cidr = cidr
-	}
-
-	if ea != nil && len(ea) > 0 {
-		network.eaSearch = EASearch(ea)
 	}
 
 	err := objMgr.connector.GetObject(network, "", &res)

--- a/object_manager.go
+++ b/object_manager.go
@@ -451,3 +451,16 @@ func (objMgr *ObjectManager) GetGridInfo() ([]Grid, error) {
 	err := objMgr.connector.GetObject(gridObj, "", &res)
 	return res, err
 }
+
+// GetRecordA returns all the A-records
+func (objMgr *ObjectManager) GetRecordA(ea EA) ([]RecordA, error) {
+	var res []RecordA
+
+	recordA := NewRecordA(RecordA{})
+	if ea != nil && len(ea) > 0 {
+		recordA.eaSearch = EASearch(ea)
+	}
+
+	err := objMgr.connector.GetObject(recordA, "", &res)
+	return res, err
+}

--- a/objects.go
+++ b/objects.go
@@ -26,7 +26,7 @@ type IBObject interface {
 	ObjectType() string
 	ReturnFields() []string
 	EaSearch() EASearch
-	//SetReturnFields([]string)
+	SetReturnFields([]string)
 }
 
 func (obj *IBBase) ObjectType() string {
@@ -37,8 +37,16 @@ func (obj *IBBase) ReturnFields() []string {
 	return obj.returnFields
 }
 
+func (obj *IBBase) SetReturnFields(returnFields []string) {
+	obj.returnFields = returnFields
+}
+
 func (obj *IBBase) EaSearch() EASearch {
 	return obj.eaSearch
+}
+
+func (obj *IBBase) SetEaSearch(eaSearch EASearch) {
+	obj.eaSearch = eaSearch
 }
 
 type NetworkView struct {


### PR DESCRIPTION
…he payload body

    * Currently the EA filters are passed as api payload, this is creating
      problem when the obj is empty and ea is requested in GET call. Hence
      moving it as URL parameter.

      `objJSON = append(append(objJSON[:len(objJSON)-1], byte(',')), eaSearchJSON[1:]...)`

    * Add Get A record call