### PR TITLE
Updation of name field in FixedAddress record

### DIFF
--- a/object_manager.go
+++ b/object_manager.go
@@ -15,9 +15,9 @@ type IBObjectManager interface {
 	GetNetworkView(name string) (*NetworkView, error)
 	GetNetwork(netview string, cidr string, ea EA) (*Network, error)
 	GetNetworkContainer(netview string, cidr string) (*NetworkContainer, error)
-	AllocateIP(netview string, cidr string, ipAddr string, macAddress string, vmID string) (*FixedAddress, error)
+	AllocateIP(netview string, cidr string, ipAddr string, macAddress string, name string, vmID string) (*FixedAddress, error)
 	AllocateNetwork(netview string, cidr string, prefixLen uint, name string) (network *Network, err error)
-	UpdateFixedAddress(fixedAddrRef string, macAddress string, vmID string) (*FixedAddress, error)
+	UpdateFixedAddress(fixedAddrRef string, macAddress string, name string, vmID string) (*FixedAddress, error)
 	GetFixedAddress(netview string, cidr string, ipAddr string, macAddr string) (*FixedAddress, error)
 	ReleaseIP(netview string, cidr string, ipAddr string, macAddr string) (string, error)
 	DeleteNetwork(ref string, netview string) (string, error)
@@ -240,7 +240,7 @@ func GetIPAddressFromRef(ref string) string {
 	return ""
 }
 
-func (objMgr *ObjectManager) AllocateIP(netview string, cidr string, ipAddr string, macAddress string, vmID string) (*FixedAddress, error) {
+func (objMgr *ObjectManager) AllocateIP(netview string, cidr string, ipAddr string, macAddress string, name string, vmID string) (*FixedAddress, error) {
 	if len(macAddress) == 0 {
 		macAddress = MACADDR_ZERO
 	}
@@ -255,6 +255,7 @@ func (objMgr *ObjectManager) AllocateIP(netview string, cidr string, ipAddr stri
 		NetviewName: netview,
 		Cidr:        cidr,
 		Mac:         macAddress,
+		Name:        name,
 		Ea:          ea})
 
 	if ipAddr == "" {
@@ -310,7 +311,7 @@ func (objMgr *ObjectManager) GetFixedAddress(netview string, cidr string, ipAddr
 	return &res[0], nil
 }
 
-func (objMgr *ObjectManager) UpdateFixedAddress(fixedAddrRef string, macAddress string, vmID string) (*FixedAddress, error) {
+func (objMgr *ObjectManager) UpdateFixedAddress(fixedAddrRef string, macAddress string, name string, vmID string) (*FixedAddress, error) {
 
 	updateFixedAddr := NewFixedAddress(FixedAddress{Ref: fixedAddrRef})
 

--- a/object_manager_test.go
+++ b/object_manager_test.go
@@ -243,6 +243,7 @@ var _ = Describe("Object Manager", func() {
 		ipAddr := "53.0.0.21"
 		macAddr := "01:23:45:67:80:ab"
 		vmID := "93f9249abc039284"
+		name := "testvm"
 		fakeRefReturn := fmt.Sprintf("fixedaddress/ZG5zLmJpbmRfY25h:%s/private", ipAddr)
 
 		asiFakeConnector := &fakeConnector{
@@ -251,6 +252,7 @@ var _ = Describe("Object Manager", func() {
 				Cidr:        cidr,
 				IPAddress:   ipAddr,
 				Mac:         macAddr,
+				Name:        name,
 			}),
 			resultObject: NewFixedAddress(FixedAddress{
 				NetviewName: netviewName,
@@ -258,6 +260,7 @@ var _ = Describe("Object Manager", func() {
 				IPAddress:   GetIPAddressFromRef(fakeRefReturn),
 				Mac:         macAddr,
 				Ref:         fakeRefReturn,
+				Name:        name,
 			}),
 			fakeRefReturn: fakeRefReturn,
 		}
@@ -273,7 +276,7 @@ var _ = Describe("Object Manager", func() {
 		var actualIP *FixedAddress
 		var err error
 		It("should pass expected Fixed Address Object to CreateObject", func() {
-			actualIP, err = objMgr.AllocateIP(netviewName, cidr, ipAddr, macAddr, vmID)
+			actualIP, err = objMgr.AllocateIP(netviewName, cidr, ipAddr, macAddr,name, vmID)
 		})
 		It("should return expected Fixed Address Object", func() {
 			Expect(actualIP).To(Equal(asiFakeConnector.resultObject))
@@ -289,6 +292,7 @@ var _ = Describe("Object Manager", func() {
 		ipAddr := fmt.Sprintf("func:nextavailableip:%s,%s", cidr, netviewName)
 		macAddr := "01:23:45:67:80:ab"
 		vmID := "93f9249abc039284"
+		name := "testvm"
 		resultIP := "53.0.0.32"
 		fakeRefReturn := fmt.Sprintf("fixedaddress/ZG5zLmJpbmRfY25h:%s/private", resultIP)
 
@@ -298,6 +302,7 @@ var _ = Describe("Object Manager", func() {
 				Cidr:        cidr,
 				IPAddress:   ipAddr,
 				Mac:         macAddr,
+				Name:        name,
 			}),
 			resultObject: NewFixedAddress(FixedAddress{
 				NetviewName: netviewName,
@@ -305,6 +310,7 @@ var _ = Describe("Object Manager", func() {
 				IPAddress:   resultIP,
 				Mac:         macAddr,
 				Ref:         fakeRefReturn,
+				Name:        name,
 			}),
 			fakeRefReturn: fakeRefReturn,
 		}
@@ -320,7 +326,7 @@ var _ = Describe("Object Manager", func() {
 		var actualIP *FixedAddress
 		var err error
 		It("should pass expected Fixed Address Object to CreateObject", func() {
-			actualIP, err = objMgr.AllocateIP(netviewName, cidr, "", macAddr, vmID)
+			actualIP, err = objMgr.AllocateIP(netviewName, cidr, "", macAddr, name, vmID)
 		})
 		It("should return expected Fixed Address Object", func() {
 			Expect(actualIP).To(Equal(aniFakeConnector.resultObject))

--- a/objects.go
+++ b/objects.go
@@ -299,6 +299,7 @@ type FixedAddress struct {
 	Cidr        string `json:"network,omitempty"`
 	IPAddress   string `json:"ipv4addr,omitempty"`
 	Mac         string `json:"mac,omitempty"`
+	Name        string `json:"name,omitempty"`
 	Ea          EA     `json:"extattrs,omitempty"`
 }
 


### PR DESCRIPTION
Presently 'name' field is left out so updating that field with
vmID value