### PR TITLE
apply request timeout to http.Client

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -139,7 +139,7 @@ func (whr *WapiHttpRequestor) Init(cfg TransportConfig) {
 		log.Fatal(err)
 	}
 
-	whr.client = http.Client{Jar: jar, Transport: tr}
+	whr.client = http.Client{Jar: jar, Transport: tr, Timeout: cfg.HttpRequestTimeout * time.Second}
 }
 
 func (whr *WapiHttpRequestor) SendRequest(req *http.Request) (res []byte, err error) {

--- a/connector.go
+++ b/connector.go
@@ -129,8 +129,7 @@ func (whr *WapiHttpRequestor) Init(cfg TransportConfig) {
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: !cfg.SslVerify,
 			RootCAs: cfg.certPool},
-		MaxIdleConnsPerHost:   cfg.HttpPoolConnections,
-		ResponseHeaderTimeout: cfg.HttpRequestTimeout * time.Second,
+		MaxIdleConnsPerHost: cfg.HttpPoolConnections,
 	}
 
 	// All users of cookiejar should import "golang.org/x/net/publicsuffix"


### PR DESCRIPTION
Right now the `cfg.HttpRequestTimeout` is only being applied to the `http.Transport.ResponseHeaderTimeout`. However, it should be applied to the entire `http.Client`. See the Client Timeout section of https://blog.cloudflare.com/the-complete-guide-to-golang-net-http-timeouts/ for more information.

`http.Client` reference: https://golang.org/pkg/net/http/#Client