### PR TITLE
Add support for array values in extensible attributes

### DIFF
--- a/objects.go
+++ b/objects.go
@@ -3,6 +3,7 @@ package ibclient
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"reflect"
 )
 
@@ -545,14 +546,26 @@ func (ea *EA) UnmarshalJSON(b []byte) (err error) {
 	*ea = make(EA)
 	for k, v := range m {
 		val := v["value"]
-		if reflect.TypeOf(val).String() == "json.Number" {
+		switch valType := reflect.TypeOf(val).String(); valType {
+		case "json.Number":
 			var i64 int64
 			i64, err = val.(json.Number).Int64()
 			val = int(i64)
-		} else if val.(string) == "True" {
-			val = Bool(true)
-		} else if val.(string) == "False" {
-			val = Bool(false)
+		case "string":
+			if val.(string) == "True" {
+				val = Bool(true)
+			} else if val.(string) == "False" {
+				val = Bool(false)
+			}
+		case "[]interface {}":
+			nval := val.([]interface{})
+			nVals := make([]string, len(nval))
+			for i, v := range nval {
+				nVals[i] = fmt.Sprintf("%v", v)
+			}
+			val = nVals
+		default:
+			val = fmt.Sprintf("%v", val)
 		}
 
 		(*ea)[k] = val

--- a/objects_test.go
+++ b/objects_test.go
@@ -77,11 +77,13 @@ var _ = Describe("Objects", func() {
 			"Tenant Name":       "Engineering01",
 			"Maximum Wait Time": 120,
 			"DNS Support":       Bool(false),
+			"Routers":           []string{"10.1.2.234", "10.1.2.235"},
 		}
 		eaJSON := `{"Cloud API Owned":{"value":"True"},` +
 			`"Tenant Name":{"value":"Engineering01"},` +
 			`"Maximum Wait Time":{"value":120},` +
-			`"DNS Support":{"value":"False"}}`
+			`"DNS Support":{"value":"False"},` +
+			`"Routers":{"value":["10.1.2.234", "10.1.2.235"]}}`
 
 		Context("Marshalling", func() {
 			Context("expected JSON is returned", func() {


### PR DESCRIPTION
The client crashes when the value of an extensible attribute is an array.
This pull request tries to handle this case.
The error message when the ea is an array is: 
```
panic: interface conversion: interface {} is []interface {}, not string

goroutine 1 [running]:
github.com/mhermida/infoblox-go-client.(*EA).UnmarshalJSON(0xc0000107e0, 0xc0001ac300, 0xbf, 0xc0, 0x7f64d6078110, 0xc0000107e0)
        /home/marcos/dev/go/hellogo/src/github.com/mhermida/infoblox-go-client/objects.go:552 +0x4cf
encoding/json.(*decodeState).object(0xc0000a7130, 0x8637a0, 0xc0000107e0, 0x16, 0xc0000a7158, 0xc00038ca7b)
...
```
Full stack error is attached.

[error_message.txt](https://github.com/infobloxopen/infoblox-go-client/files/4219860/error_message.txt)

