### PR TITLE
TTL for TXT and CNAME record, added RecordNS, ProxyUrl to TransportConfig

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -32,6 +32,7 @@ type TransportConfig struct {
 	certPool            *x509.CertPool
 	HttpRequestTimeout  time.Duration // in seconds
 	HttpPoolConnections int
+	ProxyUrl            *url.URL
 }
 
 func NewTransportConfig(sslVerify string, httpRequestTimeout int, httpPoolConnections int) (cfg TransportConfig) {
@@ -131,6 +132,10 @@ func (whr *WapiHttpRequestor) Init(cfg TransportConfig) {
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: !cfg.SslVerify,
 			RootCAs: cfg.certPool},
 		MaxIdleConnsPerHost: cfg.HttpPoolConnections,
+	}
+
+	if cfg.ProxyUrl != nil {
+		tr.Proxy = http.ProxyURL(cfg.ProxyUrl)
 	}
 
 	// All users of cookiejar should import "golang.org/x/net/publicsuffix"

--- a/object_manager.go
+++ b/object_manager.go
@@ -568,13 +568,13 @@ func (objMgr *ObjectManager) DeleteCNAMERecord(ref string) (string, error) {
 }
 
 // Creates TXT Record. Use TTL of 0 to inherit TTL from the Zone
-func (objMgr *ObjectManager) CreateTXTRecord(recordname string, text string, ttl int, dnsview string) (*RecordTXT, error) {
+func (objMgr *ObjectManager) CreateTXTRecord(recordname string, text string, ttl uint, dnsview string) (*RecordTXT, error) {
 
 	recordTXT := NewRecordTXT(RecordTXT{
 		View: dnsview,
 		Name: recordname,
 		Text: text,
-		TTL:  ttl,
+		Ttl:  ttl,
 	})
 
 	ref, err := objMgr.connector.CreateObject(recordTXT)

--- a/object_manager_test.go
+++ b/object_manager_test.go
@@ -934,14 +934,14 @@ var _ = Describe("Object Manager", func() {
 		text := "test-text"
 		dnsView := "default"
 		recordName := "test"
-		ttl := 30
+		ttl := uint(30)
 		fakeRefReturn := fmt.Sprintf("record:txt/ZG5zLmJpbmRfY25h:%s/%20%20", recordName)
 
 		aniFakeConnector := &fakeConnector{
 			createObjectObj: NewRecordTXT(RecordTXT{
 				Name: recordName,
 				Text: text,
-				TTL:  ttl,
+				Ttl:  ttl,
 				View: dnsView,
 			}),
 			getObjectRef: fakeRefReturn,
@@ -950,12 +950,13 @@ var _ = Describe("Object Manager", func() {
 				Text: text,
 				View: dnsView,
 				Ref:  fakeRefReturn,
+				Ttl:  ttl,
 			}),
 			resultObject: NewRecordTXT(RecordTXT{
 				Name: recordName,
 				Text: text,
 				View: dnsView,
-				TTL:  ttl,
+				Ttl:  ttl,
 				Ref:  fakeRefReturn,
 			}),
 			fakeRefReturn: fakeRefReturn,

--- a/objects.go
+++ b/objects.go
@@ -396,12 +396,14 @@ type RecordCNAME struct {
 	View      string `json:"view,omitempty"`
 	Zone      string `json:"zone,omitempty"`
 	Ea        EA     `json:"extattrs,omitempty"`
+	Ttl       uint   `json:"ttl,omitempty"`
+	UseTtl    bool   `json:"use_ttl,omitempty"`
 }
 
 func NewRecordCNAME(rc RecordCNAME) *RecordCNAME {
 	res := rc
 	res.objectType = "record:cname"
-	res.returnFields = []string{"extattrs", "canonical", "name", "view", "zone"}
+	res.returnFields = []string{"extattrs", "canonical", "name", "view", "zone", "ttl", "use_ttl"}
 
 	return &res
 }
@@ -447,16 +449,17 @@ type RecordTXT struct {
 	Ref    string `json:"_ref,omitempty"`
 	Name   string `json:"name,omitempty"`
 	Text   string `json:"text,omitempty"`
-	TTL    int    `json:"ttl,omitempty"`
+	Ttl    uint   `json:"ttl,omitempty"`
 	View   string `json:"view,omitempty"`
 	Zone   string `json:"zone,omitempty"`
 	Ea     EA     `json:"extattrs,omitempty"`
+	UseTtl bool   `json:"use_ttl,omitempty"`
 }
 
 func NewRecordTXT(rt RecordTXT) *RecordTXT {
 	res := rt
 	res.objectType = "record:txt"
-	res.returnFields = []string{"extattrs", "name", "text", "view", "zone"}
+	res.returnFields = []string{"extattrs", "name", "text", "view", "zone", "ttl", "use_ttl"}
 
 	return &res
 }

--- a/objects_test.go
+++ b/objects_test.go
@@ -362,7 +362,7 @@ var _ = Describe("Objects", func() {
 
 			It("should set base fields correctly", func() {
 				Expect(rc.ObjectType()).To(Equal("record:cname"))
-				Expect(rc.ReturnFields()).To(ConsistOf("extattrs", "canonical", "name", "view", "zone"))
+				Expect(rc.ReturnFields()).To(ConsistOf("extattrs", "canonical", "name", "view", "zone", "ttl", "use_ttl"))
 			})
 		})
 
@@ -456,7 +456,7 @@ var _ = Describe("Objects", func() {
 
 			It("should set base fields correctly", func() {
 				Expect(rt.ObjectType()).To(Equal("record:txt"))
-				Expect(rt.ReturnFields()).To(ConsistOf("extattrs", "name", "text", "view", "zone"))
+				Expect(rt.ReturnFields()).To(ConsistOf("extattrs", "name", "text", "view", "zone", "ttl", "use_ttl"))
 			})
 		})
 

--- a/record_ns.go
+++ b/record_ns.go
@@ -1,0 +1,23 @@
+package ibclient
+
+type RecordNS struct {
+	IBBase     `json:"-"`
+	Ref        string           `json:"_ref,omitempty"`
+	Addresses  []ZoneNameServer `json:"addresses,omitempty"`
+	Name       string           `json:"name,omitempty"`
+	Nameserver string           `json:"nameserver,omitempty"`
+	View       string           `json:"view,omitempty"`
+	Zone       string           `json:"zone,omitempty"`
+}
+
+func NewRecordNS(rc RecordNS) *RecordNS {
+	res := rc
+	res.objectType = "record:ns"
+	res.returnFields = []string{"addresses", "name", "nameserver", "view", "zone"}
+
+	return &res
+}
+
+type ZoneNameServer struct {
+	Address string `json:"address,omitempty"`
+}


### PR DESCRIPTION
There were some missing pieces for using this client for our purposes.
We integrated Infoblox DNS as a provider in our project external-dns-management (https://github.com/gardener/external-dns-management/pull/98).
For this purpose, we added:
- TTL fields for TXT and CNAME records
  There was also an inconsistency in writing `Ttl` or `TTL`. As most code uses `Ttl`, this convention is used here too
- struct RecordNS to be able to query NS records
- `ProxyUrl` as option in the TransportConfig. In our development environment, the Infoblox DNS grid is only reachable through a reverse proxy.
