### PR TITLE
Update object_manager.go to get already exist host record error

### DIFF
--- a/object_manager.go
+++ b/object_manager.go
@@ -457,6 +457,9 @@ func (objMgr *ObjectManager) CreateHostRecord(enabledns bool, recordName string,
 		Ea:          eas})
 
 	ref, err := objMgr.connector.CreateObject(recordHost)
+	if err != nil {
+		return nil,err
+	}
 	recordHost.Ref = ref
 	err = objMgr.connector.GetObject(recordHost, ref, &recordHost)
 	return recordHost, err


### PR DESCRIPTION
The CreateHostRecord method return a wrong error in case the request involve an already existing host record:

Contents:
{ "Error": "AdmConProtoError: Field is not searchable: configure_for_dns", 
  "code": "Client.Ibap.Proto", 
  "text": "Field is not searchable: configure_for_dns"
}

This error comes from the getObject and not from the createObject, indeed in case of error I should be able to know why I couldn't create the requested object.

Thanks,
F.