### PR TITLE
Omit cloud attrs

### DIFF
--- a/object_manager.go
+++ b/object_manager.go
@@ -48,6 +48,8 @@ type ObjectManager struct {
 	connector IBConnector
 	cmpType   string
 	tenantID  string
+	// If OmitCloudAttrs is true no extra attributes for cloud are set
+	OmitCloudAttrs bool
 }
 
 func NewObjectManager(connector IBConnector, cmpType string, tenantID string) *ObjectManager {
@@ -62,9 +64,11 @@ func NewObjectManager(connector IBConnector, cmpType string, tenantID string) *O
 
 func (objMgr *ObjectManager) getBasicEA(cloudAPIOwned Bool) EA {
 	ea := make(EA)
-	ea["Cloud API Owned"] = cloudAPIOwned
-	ea["CMP Type"] = objMgr.cmpType
-	ea["Tenant ID"] = objMgr.tenantID
+	if !objMgr.OmitCloudAttrs {
+		ea["Cloud API Owned"] = cloudAPIOwned
+		ea["CMP Type"] = objMgr.cmpType
+		ea["Tenant ID"] = objMgr.tenantID
+	}
 	return ea
 }
 

--- a/object_manager_test.go
+++ b/object_manager_test.go
@@ -1739,4 +1739,14 @@ var _ = Describe("Object Manager", func() {
 		})
 	})
 
+	Describe("Omit cloud attributes", func() {
+		connector := &fakeConnector{}
+		objMgr := NewObjectManager(connector, "", "")
+		objMgr.OmitCloudAttrs = true
+
+		ea := objMgr.getBasicEA(true)
+		It("should return empty EA", func() {
+			Expect(len(ea)).To(Equal(0))
+		})
+	})
 })


### PR DESCRIPTION
Add option to skip getting cloud attributes for on-prem deployments

Fixes #79 