### PR TITLE
Adding tls renagotiate

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -129,7 +129,8 @@ func getHTTPResponseError(resp *http.Response) error {
 func (whr *WapiHttpRequestor) Init(cfg TransportConfig) {
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: !cfg.SslVerify,
-			RootCAs: cfg.certPool},
+			RootCAs: cfg.certPool,
+			Renegotiation:      tls.RenegotiateOnceAsClient},
 		MaxIdleConnsPerHost: cfg.HttpPoolConnections,
 	}
 


### PR DESCRIPTION
Ading TLS renagotiate flag. In client's environment all interactions fail due to renagotiate not being enabled.