### PR TITLE
Use proxy env variables if explicit proxy not set

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -133,6 +133,7 @@ func (whr *WapiHttpRequestor) Init(cfg TransportConfig) {
 			RootCAs: cfg.certPool,
 			Renegotiation:      tls.RenegotiateOnceAsClient},
 		MaxIdleConnsPerHost: cfg.HttpPoolConnections,
+		Proxy: http.ProxyFromEnvironment,
 	}
 
 	if cfg.ProxyUrl != nil {


### PR DESCRIPTION
With this change, users can use the de facto standard HTTP(S)_PROXY environment variables instead of having to specify them manually. 
See https://golang.org/pkg/net/http/#ProxyFromEnvironment

I think using the environment variables is what you often get by [default](https://github.com/golang/go/blob/2e59cc5fb4e81fbd2ee9f662caa707c1138bf5ae/src/net/http/transport.go#L44)?? (sorry, I'm new to go)