### PR TITLE
Ensure IBObjectManager is compatible with ObjectManager (#121)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ This library is compatible with Go 1.2+
 - [Installation](#Installation)
 - [Usage](#Usage)
 
+## Build Status
+
+| Master                                                                                                                                          | Develop                                                                                                                                                           |
+| ----------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [![Build Status](https://travis-ci.org/infobloxopen/infoblox-go-client.svg?branch=master)](https://travis-ci.org/infobloxopen/infoblox-go-client) | [![Build Status](https://travis-ci.org/infobloxopen/infoblox-go-client.svg?branch=develop)](https://travis-ci.org/infobloxopen/infoblox-go-client) |
+
+
 ## Prerequisites
    * Infoblox GRID with 2.5 or above WAPI support
    * Go 1.2 or above

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Infoblox Go Client
 
-An Infoblox Client library for Go.
+An Infoblox NIOS WAPI client library in Golang.
+The library enables us to do a CRUD oprations on NIOS Objects.
 
 This library is compatible with Go 1.2+
 
@@ -55,22 +56,47 @@ This library is compatible with Go 1.2+
 
 ## Supported NIOS operations
 
+   * AllocateIP
    * AllocateNetwork
+   * CreateARecord
+   * CreateZoneAuth
+   * CreateCNAMERecord
    * CreateDefaultNetviews
    * CreateEADefinition
+   * CreateHostRecord
    * CreateNetwork
    * CreateNetworkContainer
    * CreateNetworkView
+   * CreatePTRRecord
+   * DeleteARecord
+   * DeleteZoneAuth
+   * DeleteCNAMERecord
+   * DeleteFixedAddress
+   * DeleteHostRecord
    * DeleteNetwork
    * DeleteNetworkView
+   * DeletePTRRecord
    * GetAllMembers
+   * GetARecordByRef
    * GetCapacityReport
+   * GetCNAMERecordByRef
    * GetEADefinition
    * GetFixedAddress
+   * GetFixedAddressByRef
+   * GetHostRecord
+   * GetHostRecordByRef
+   * GetIpAddressFromHostRecord
    * GetNetwork
    * GetNetworkContainer
    * GetNetworkView
+   * GetPTRRecordByRef
    * GetUpgradeStatus (2.7 or above)
+   * GetZoneAuthByRef
    * ReleaseIP
    * UpdateFixedAddress
+   * UpdateHostRecord
    * UpdateNetworkViewEA
+   * UpdateARecord
+   * UpdateCNAMERecord
+
+The newly developed features will be available under `develop` branch. After validation they would be merged to `master`.

--- a/connector.go
+++ b/connector.go
@@ -133,6 +133,7 @@ func (whr *WapiHttpRequestor) Init(cfg TransportConfig) {
 			RootCAs: cfg.certPool,
 			Renegotiation:      tls.RenegotiateOnceAsClient},
 		MaxIdleConnsPerHost: cfg.HttpPoolConnections,
+		Proxy: http.ProxyFromEnvironment,
 	}
 
 	if cfg.ProxyUrl != nil {

--- a/connector.go
+++ b/connector.go
@@ -32,6 +32,7 @@ type TransportConfig struct {
 	certPool            *x509.CertPool
 	HttpRequestTimeout  time.Duration // in seconds
 	HttpPoolConnections int
+	ProxyUrl            *url.URL
 }
 
 func NewTransportConfig(sslVerify string, httpRequestTimeout int, httpPoolConnections int) (cfg TransportConfig) {
@@ -132,6 +133,10 @@ func (whr *WapiHttpRequestor) Init(cfg TransportConfig) {
 			RootCAs: cfg.certPool,
 			Renegotiation:      tls.RenegotiateOnceAsClient},
 		MaxIdleConnsPerHost: cfg.HttpPoolConnections,
+	}
+
+	if cfg.ProxyUrl != nil {
+		tr.Proxy = http.ProxyURL(cfg.ProxyUrl)
 	}
 
 	// All users of cookiejar should import "golang.org/x/net/publicsuffix"

--- a/object_manager.go
+++ b/object_manager.go
@@ -605,13 +605,13 @@ func (objMgr *ObjectManager) DeleteCNAMERecord(ref string) (string, error) {
 }
 
 // Creates TXT Record. Use TTL of 0 to inherit TTL from the Zone
-func (objMgr *ObjectManager) CreateTXTRecord(recordname string, text string, ttl int, dnsview string) (*RecordTXT, error) {
+func (objMgr *ObjectManager) CreateTXTRecord(recordname string, text string, ttl uint, dnsview string) (*RecordTXT, error) {
 
 	recordTXT := NewRecordTXT(RecordTXT{
 		View: dnsview,
 		Name: recordname,
 		Text: text,
-		TTL:  ttl,
+		Ttl:  ttl,
 	})
 
 	ref, err := objMgr.connector.CreateObject(recordTXT)

--- a/object_manager.go
+++ b/object_manager.go
@@ -21,7 +21,7 @@ type IBObjectManager interface {
 	CreateNetworkView(name string) (*NetworkView, error)
 	CreatePTRRecord(netview string, dnsview string, recordname string, cidr string, ipAddr string, ea EA) (*RecordPTR, error)
 	DeleteARecord(ref string) (string, error)
-	DeleteZoneAuth(ref string) (string, error) 
+	DeleteZoneAuth(ref string) (string, error)
 	DeleteCNAMERecord(ref string) (string, error)
 	DeleteFixedAddress(ref string) (string, error)
 	DeleteHostRecord(ref string) (string, error)
@@ -45,6 +45,7 @@ type IBObjectManager interface {
 	UpdateFixedAddress(fixedAddrRef string, matchclient string, macAddress string, vmID string, vmName string) (*FixedAddress, error)
 	UpdateHostRecord(hostRref string, ipAddr string, macAddress string, vmID string, vmName string) (string, error)
 	UpdateNetworkViewEA(ref string, addEA EA, removeEA EA) error
+	UpdateARecord(aRecordRef string, netview string, recordname string, cidr string, ipAddr string, ea EA) (*RecordA, error)
 }
 
 type ObjectManager struct {
@@ -548,6 +549,21 @@ func (objMgr *ObjectManager) GetARecordByRef(ref string) (*RecordA, error) {
 	err := objMgr.connector.GetObject(recordA, ref, &recordA)
 	return recordA, err
 }
+
+func (objMgr *ObjectManager) UpdateARecord(aRecordRef string, netview string, recordname string, cidr string, ipAddr string, ea EA) (*RecordA, error) {
+	updateRecordA := NewRecordA(RecordA{Ref: aRecordRef})
+	updateRecordA.Name = recordname
+	if ipAddr != "" {
+		updateRecordA.Ipv4Addr = ipAddr
+	} else {
+		updateRecordA.Ipv4Addr = fmt.Sprintf("func:nextavailableip:%s,%s", cidr, netview)
+	}
+	updateRecordA.Ea = ea
+	refResp, err := objMgr.connector.UpdateObject(updateRecordA, aRecordRef)
+	updateRecordA.Ref = refResp
+	return updateRecordA, err
+}
+
 func (objMgr *ObjectManager) DeleteARecord(ref string) (string, error) {
 	return objMgr.connector.DeleteObject(ref)
 }
@@ -571,6 +587,16 @@ func (objMgr *ObjectManager) GetCNAMERecordByRef(ref string) (*RecordCNAME, erro
 	recordCNAME := NewRecordCNAME(RecordCNAME{})
 	err := objMgr.connector.GetObject(recordCNAME, ref, &recordCNAME)
 	return recordCNAME, err
+}
+
+func (objMgr *ObjectManager) UpdateCNAMERecord(cnameRef string, canonical string, recordname, string, dnsview string, ea EA) (*RecordCNAME, error) {
+	updateRecordCNAME := NewRecordCNAME(RecordCNAME{Ref: cnameRef})
+	updateRecordCNAME.Canonical = canonical
+	updateRecordCNAME.Name = recordname
+	updateRecordCNAME.Ea = ea
+	refResp, err := objMgr.connector.UpdateObject(updateRecordCNAME, cnameRef)
+	updateRecordCNAME.Ref = refResp
+	return updateRecordCNAME, err
 }
 
 func (objMgr *ObjectManager) DeleteCNAMERecord(ref string) (string, error) {
@@ -761,16 +787,15 @@ func (objMgr *ObjectManager) CreateZoneAuth(fqdn string, ea EA) (*ZoneAuth, erro
 	eas := objMgr.extendEA(ea)
 
 	zoneAuth := NewZoneAuth(ZoneAuth{
-		Fqdn:     fqdn,
-		Ea:       eas})
-
+		Fqdn: fqdn,
+		Ea:   eas})
 
 	ref, err := objMgr.connector.CreateObject(zoneAuth)
 	zoneAuth.Ref = ref
 	return zoneAuth, err
 }
 
-// Retreive a authortative zone by ref 
+// Retreive a authortative zone by ref
 func (objMgr *ObjectManager) GetZoneAuthByRef(ref string) (ZoneAuth, error) {
 	var res ZoneAuth
 

--- a/object_manager.go
+++ b/object_manager.go
@@ -46,6 +46,7 @@ type IBObjectManager interface {
 	UpdateHostRecord(hostRref string, ipAddr string, macAddress string, vmID string, vmName string) (string, error)
 	UpdateNetworkViewEA(ref string, addEA EA, removeEA EA) error
 	UpdateARecord(aRecordRef string, netview string, recordname string, cidr string, ipAddr string, ea EA) (*RecordA, error)
+	UpdateCNAMERecord(cnameRef string, canonical string, recordname string, dnsview string, ea EA) (*RecordCNAME, error)
 }
 
 type ObjectManager struct {
@@ -589,7 +590,7 @@ func (objMgr *ObjectManager) GetCNAMERecordByRef(ref string) (*RecordCNAME, erro
 	return recordCNAME, err
 }
 
-func (objMgr *ObjectManager) UpdateCNAMERecord(cnameRef string, canonical string, recordname, string, dnsview string, ea EA) (*RecordCNAME, error) {
+func (objMgr *ObjectManager) UpdateCNAMERecord(cnameRef string, canonical string, recordname string, dnsview string, ea EA) (*RecordCNAME, error) {
 	updateRecordCNAME := NewRecordCNAME(RecordCNAME{Ref: cnameRef})
 	updateRecordCNAME.Canonical = canonical
 	updateRecordCNAME.Name = recordname

--- a/object_manager.go
+++ b/object_manager.go
@@ -7,6 +7,9 @@ import (
 	"regexp"
 )
 
+// Compile time interface checks
+var _ IBObjectManager = new(ObjectManager)
+
 type IBObjectManager interface {
 	AllocateIP(netview string, cidr string, ipAddr string, macAddress string, name string, ea EA) (*FixedAddress, error)
 	AllocateNetwork(netview string, cidr string, prefixLen uint, name string) (network *Network, err error)
@@ -29,7 +32,7 @@ type IBObjectManager interface {
 	DeleteNetworkView(ref string) (string, error)
 	DeletePTRRecord(ref string) (string, error)
 	GetARecordByRef(ref string) (*RecordA, error)
-	GetCNAMERecordByRef(ref string) (*RecordA, error)
+	GetCNAMERecordByRef(ref string) (*RecordCNAME, error)
 	GetEADefinition(name string) (*EADefinition, error)
 	GetFixedAddress(netview string, cidr string, ipAddr string, macAddr string) (*FixedAddress, error)
 	GetFixedAddressByRef(ref string) (*FixedAddress, error)
@@ -40,7 +43,7 @@ type IBObjectManager interface {
 	GetNetworkContainer(netview string, cidr string) (*NetworkContainer, error)
 	GetNetworkView(name string) (*NetworkView, error)
 	GetPTRRecordByRef(ref string) (*RecordPTR, error)
-	GetZoneAuthByRef(ref string) (*ZoneAuth, error)
+	GetZoneAuthByRef(ref string) (ZoneAuth, error)
 	ReleaseIP(netview string, cidr string, ipAddr string, macAddr string) (string, error)
 	UpdateFixedAddress(fixedAddrRef string, matchclient string, macAddress string, vmID string, vmName string) (*FixedAddress, error)
 	UpdateHostRecord(hostRref string, ipAddr string, macAddress string, vmID string, vmName string) (string, error)

--- a/object_manager_test.go
+++ b/object_manager_test.go
@@ -936,14 +936,14 @@ var _ = Describe("Object Manager", func() {
 		text := "test-text"
 		dnsView := "default"
 		recordName := "test"
-		ttl := 30
+		ttl := uint(30)
 		fakeRefReturn := fmt.Sprintf("record:txt/ZG5zLmJpbmRfY25h:%s/%20%20", recordName)
 
 		aniFakeConnector := &fakeConnector{
 			createObjectObj: NewRecordTXT(RecordTXT{
 				Name: recordName,
 				Text: text,
-				TTL:  ttl,
+				Ttl:  ttl,
 				View: dnsView,
 			}),
 			getObjectRef: fakeRefReturn,
@@ -952,12 +952,13 @@ var _ = Describe("Object Manager", func() {
 				Text: text,
 				View: dnsView,
 				Ref:  fakeRefReturn,
+				Ttl:  ttl,
 			}),
 			resultObject: NewRecordTXT(RecordTXT{
 				Name: recordName,
 				Text: text,
 				View: dnsView,
-				TTL:  ttl,
+				Ttl:  ttl,
 				Ref:  fakeRefReturn,
 			}),
 			fakeRefReturn: fakeRefReturn,

--- a/objects.go
+++ b/objects.go
@@ -396,12 +396,14 @@ type RecordCNAME struct {
 	View      string `json:"view,omitempty"`
 	Zone      string `json:"zone,omitempty"`
 	Ea        EA     `json:"extattrs,omitempty"`
+	Ttl       uint   `json:"ttl,omitempty"`
+	UseTtl    bool   `json:"use_ttl,omitempty"`
 }
 
 func NewRecordCNAME(rc RecordCNAME) *RecordCNAME {
 	res := rc
 	res.objectType = "record:cname"
-	res.returnFields = []string{"extattrs", "canonical", "name", "view", "zone"}
+	res.returnFields = []string{"extattrs", "canonical", "name", "view", "zone", "ttl", "use_ttl"}
 
 	return &res
 }
@@ -447,16 +449,17 @@ type RecordTXT struct {
 	Ref    string `json:"_ref,omitempty"`
 	Name   string `json:"name,omitempty"`
 	Text   string `json:"text,omitempty"`
-	TTL    int    `json:"ttl,omitempty"`
+	Ttl    uint   `json:"ttl,omitempty"`
 	View   string `json:"view,omitempty"`
 	Zone   string `json:"zone,omitempty"`
 	Ea     EA     `json:"extattrs,omitempty"`
+	UseTtl bool   `json:"use_ttl,omitempty"`
 }
 
 func NewRecordTXT(rt RecordTXT) *RecordTXT {
 	res := rt
 	res.objectType = "record:txt"
-	res.returnFields = []string{"extattrs", "name", "text", "view", "zone"}
+	res.returnFields = []string{"extattrs", "name", "text", "view", "zone", "ttl", "use_ttl"}
 
 	return &res
 }

--- a/objects_test.go
+++ b/objects_test.go
@@ -362,7 +362,7 @@ var _ = Describe("Objects", func() {
 
 			It("should set base fields correctly", func() {
 				Expect(rc.ObjectType()).To(Equal("record:cname"))
-				Expect(rc.ReturnFields()).To(ConsistOf("extattrs", "canonical", "name", "view", "zone"))
+				Expect(rc.ReturnFields()).To(ConsistOf("extattrs", "canonical", "name", "view", "zone", "ttl", "use_ttl"))
 			})
 		})
 
@@ -456,7 +456,7 @@ var _ = Describe("Objects", func() {
 
 			It("should set base fields correctly", func() {
 				Expect(rt.ObjectType()).To(Equal("record:txt"))
-				Expect(rt.ReturnFields()).To(ConsistOf("extattrs", "name", "text", "view", "zone"))
+				Expect(rt.ReturnFields()).To(ConsistOf("extattrs", "name", "text", "view", "zone", "ttl", "use_ttl"))
 			})
 		})
 

--- a/record_ns.go
+++ b/record_ns.go
@@ -1,0 +1,23 @@
+package ibclient
+
+type RecordNS struct {
+	IBBase     `json:"-"`
+	Ref        string           `json:"_ref,omitempty"`
+	Addresses  []ZoneNameServer `json:"addresses,omitempty"`
+	Name       string           `json:"name,omitempty"`
+	Nameserver string           `json:"nameserver,omitempty"`
+	View       string           `json:"view,omitempty"`
+	Zone       string           `json:"zone,omitempty"`
+}
+
+func NewRecordNS(rc RecordNS) *RecordNS {
+	res := rc
+	res.objectType = "record:ns"
+	res.returnFields = []string{"addresses", "name", "nameserver", "view", "zone"}
+
+	return &res
+}
+
+type ZoneNameServer struct {
+	Address string `json:"address,omitempty"`
+}


### PR DESCRIPTION
Related to #122 

The given interface does not adhere to the implementation (typos) and is unusable for dependency injection. This PR adds a compile-time check and updates the interface to be compatible with the struct.

Considering that the interface is unusable right now, I don't think this will cause any issues with backwards compatibility.