### PR TITLE
Add compile-time interface check

### DIFF
--- a/object_manager.go
+++ b/object_manager.go
@@ -9,6 +9,9 @@ import (
 	"regexp"
 )
 
+// Compile-time interface checks
+var _ IBObjectManager = new(ObjectManager)
+
 type IBObjectManager interface {
 	AllocateIP(netview string, cidr string, ipAddr string, isIPv6 bool, macAddress string, name string, comment string, eas EA) (*FixedAddress, error)
 	AllocateNetwork(netview string, cidr string, isIPv6 bool, prefixLen uint, comment string, eas EA) (network *Network, err error)


### PR DESCRIPTION
Adds a compile-time check to the interface to make sure it stays in sync with the actual implementation.