### PR TITLE
fix go.mod module for v2.x.x

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/infobloxopen/infoblox-go-client
+module github.com/infobloxopen/infoblox-go-client/v2
 
 go 1.15
 


### PR DESCRIPTION
The new release v2.0.0 cannot be imported anymore.

Trying to import `github.com/infobloxopen/infoblox-go-client v2.0.0` results in this error with golang 1.16

```txt
go: errors parsing go.mod:
.../go.mod:19:2: require github.com/infobloxopen/infoblox-go-client: version "v2.0.0" invalid: should be v0 or v1, not v2
```

Trying to import `github.com/infobloxopen/infoblox-go-client/v2 v2.0.0`

```txt
go: github.com/infobloxopen/infoblox-go-client/v2@v2.0.0: go.mod has non-.../v2 module path "github.com/infobloxopen/infoblox-go-client" (and .../v2/go.mod does not exist) at revision v2.0.0
```

The simplest resolution is to adjust the module in `go.mod`