### PR TITLE
remove develop branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,7 @@ This library is compatible with Go 1.2+
 - [Usage](#Usage)
 
 ## Build Status
-
-| Master                                                                                                                                          | 
-| ----------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [![Build Status](https://travis-ci.org/infobloxopen/infoblox-go-client.svg?branch=master)](https://travis-ci.org/infobloxopen/infoblox-go-client) |
+[![Build Status](https://travis-ci.org/infobloxopen/infoblox-go-client.svg?branch=master)](https://travis-ci.org/infobloxopen/infoblox-go-client) 
 
 
 ## Prerequisites

--- a/README.md
+++ b/README.md
@@ -11,11 +11,10 @@ This library is compatible with Go 1.2+
 
 ## Build Status
 
-| Master                                                                                                                                          | Develop                                                                                                                                                           |
+| Master                                                                                                                                          | 
 | ----------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [![Build Status](https://travis-ci.org/infobloxopen/infoblox-go-client.svg?branch=master)](https://travis-ci.org/infobloxopen/infoblox-go-client) | [![Build Status](https://travis-ci.org/infobloxopen/infoblox-go-client.svg?branch=develop)](https://travis-ci.org/infobloxopen/infoblox-go-client) |
+| [![Build Status](https://travis-ci.org/infobloxopen/infoblox-go-client.svg?branch=master)](https://travis-ci.org/infobloxopen/infoblox-go-client) |
 
-The newly developed features will be available under `develop` branch. After validation they would be merged to `master`.
 
 ## Prerequisites
    * Infoblox GRID with 2.5 or above WAPI support


### PR DESCRIPTION
A request has been made by community users and developers to remove develop branch and maintain only master branch. Since it created more confusion and also considerable efforts to maintain 2 branches.