### PR TITLE
Added NIOS operation to allocate network container

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ This library is compatible with Go 1.2+
 
    * AllocateIP
    * AllocateNetwork
+   * AllocateNetworkContainer
    * CreateARecord
    * CreateAAAARecord
    * CreateZoneAuth

--- a/connector.go
+++ b/connector.go
@@ -133,7 +133,7 @@ func (whr *WapiHttpRequestor) Init(cfg TransportConfig) {
 			RootCAs:       cfg.certPool,
 			Renegotiation: tls.RenegotiateOnceAsClient},
 		MaxIdleConnsPerHost: cfg.HttpPoolConnections,
-		Proxy: http.ProxyFromEnvironment,
+		Proxy:               http.ProxyFromEnvironment,
 	}
 
 	if cfg.ProxyUrl != nil {

--- a/object_manager_test.go
+++ b/object_manager_test.go
@@ -1171,6 +1171,117 @@ var _ = Describe("Object Manager", func() {
 		})
 	})
 
+	Describe("Allocate Network Container", func() {
+		cmpType := "Docker"
+		tenantID := "01234567890abcdef01234567890abcdef"
+		netviewName := "default_view"
+		cidr := "142.0.22.0/24"
+		prefixLen := uint(28)
+		networkName := "private-net"
+		fakeRefReturn := fmt.Sprintf("networkcontainer/ZG5zLm5ldHdvcmskODkuMC4wLjAvMjQvMjU:%s/%s", cidr, netviewName)
+		ea := EA{"Site": "test"}
+		comment := "Test network container"
+		resObj, err := BuildNetworkContainerFromRef(fakeRefReturn)
+
+		containerInfo := NewNetworkContainerNextAvailableInfo(netviewName, cidr, prefixLen, false)
+		container := NewNetworkContainerNextAvailable(containerInfo, false, comment, ea)
+
+		connector := &fakeConnector{
+			createObjectObj: container,
+			resultObject:    resObj,
+			fakeRefReturn:   fakeRefReturn,
+		}
+
+		objMgr := NewObjectManager(connector, cmpType, tenantID)
+
+		connector.createObjectObj.(*NetworkContainerNextAvailable).Ea = ea
+		connector.createObjectObj.(*NetworkContainerNextAvailable).Ea["Network Name"] = networkName
+
+		var actualNetwork *NetworkContainer
+		It("should pass expected Network Container Object to CreateObject", func() {
+			actualNetwork, err = objMgr.AllocateNetworkContainer(
+				netviewName, cidr, false, prefixLen, comment, ea)
+		})
+		It("should return expected Network Object", func() {
+			Expect(actualNetwork).To(Equal(connector.resultObject))
+			Expect(err).To(BeNil())
+		})
+	})
+
+	Describe("Does not allocate Network Container if an invalid cidr is passed", func() {
+		cmpType := "Docker"
+		tenantID := "01234567890abcdef01234567890abcdef"
+		netviewName := "default_view"
+		cidr := "10.0.1.0./64"
+		prefixLen := uint(65)
+		networkName := "private-net"
+		fakeRefReturn := fmt.Sprintf("networkcontainer/ZG5zLm5ldHdvcmskODkuMC4wLjAvMjQvMjU:%s/%s", cidr, netviewName)
+		ea := EA{"Site": "test"}
+		comment := "Test network container"
+		resObj, err := BuildNetworkContainerFromRef(fakeRefReturn)
+
+		containerInfo := NewNetworkContainerNextAvailableInfo(netviewName, cidr, prefixLen, false)
+		container := NewNetworkContainerNextAvailable(containerInfo, false, comment, ea)
+
+		connector := &fakeConnector{
+			createObjectObj: container,
+			resultObject:    resObj,
+			fakeRefReturn:   fakeRefReturn,
+		}
+
+		objMgr := NewObjectManager(connector, cmpType, tenantID)
+
+		connector.createObjectObj.(*NetworkContainerNextAvailable).Ea = ea
+		connector.createObjectObj.(*NetworkContainerNextAvailable).Ea["Network Name"] = networkName
+
+		var actualNetwork *NetworkContainer
+		It("should pass expected Network Container Object with invalid Cidr value to CreateObject", func() {
+			actualNetwork, err = objMgr.AllocateNetworkContainer(
+				netviewName, cidr, false, prefixLen, comment, ea)
+		})
+		It("should return nil and an error message", func() {
+			Expect(actualNetwork).To(Equal(connector.resultObject))
+			Expect(err).To(Equal(fmt.Errorf("CIDR format not matched")))
+		})
+	})
+
+	Describe("Allocate Network Container", func() {
+		cmpType := "Docker"
+		tenantID := "01234567890abcdef01234567890abcdef"
+		netviewName := "default_view"
+		cidr := "2003:db8:abcd:14::/64"
+		prefixLen := uint(28)
+		networkName := "private-net"
+		fakeRefReturn := fmt.Sprintf("ipv6networkcontainer/ZG5zLm5ldHdvcmskODkuMC4wLjAvMjQvMjU:%s/%s", cidr, netviewName)
+		ea := EA{"Site": "test"}
+		comment := "Test network container"
+		resObj, err := BuildIPv6NetworkContainerFromRef(fakeRefReturn)
+		fmt.Println(resObj)
+		containerInfo := NewNetworkContainerNextAvailableInfo(netviewName, cidr, prefixLen, true)
+		container := NewNetworkContainerNextAvailable(containerInfo, true, comment, ea)
+
+		connector := &fakeConnector{
+			createObjectObj: container,
+			resultObject:    resObj,
+			fakeRefReturn:   fakeRefReturn,
+		}
+
+		objMgr := NewObjectManager(connector, cmpType, tenantID)
+
+		connector.createObjectObj.(*NetworkContainerNextAvailable).Ea = ea
+		connector.createObjectObj.(*NetworkContainerNextAvailable).Ea["Network Name"] = networkName
+
+		var actualNetwork *NetworkContainer
+		It("should pass expected Network Container Object to CreateObject", func() {
+			actualNetwork, err = objMgr.AllocateNetworkContainer(
+				netviewName, cidr, true, prefixLen, comment, ea)
+		})
+		It("should return expected Network Object", func() {
+			Expect(actualNetwork).To(Equal(connector.resultObject))
+			Expect(err).To(BeNil())
+		})
+	})
+
 	Describe("Allocate Specific IP", func() {
 		cmpType := "Docker"
 		tenantID := "01234567890abcdef01234567890abcdef"

--- a/objects.go
+++ b/objects.go
@@ -43,11 +43,11 @@ func (obj *IBBase) EaSearch() EASearch {
 }
 
 type NetworkView struct {
-	IBBase `json:"-"`
-	Ref    string `json:"_ref,omitempty"`
-	Name   string `json:"name,omitempty"`
+	IBBase  `json:"-"`
+	Ref     string `json:"_ref,omitempty"`
+	Name    string `json:"name,omitempty"`
 	Comment string `json:"comment"`
-	Ea     EA     `json:"extattrs"`
+	Ea      EA     `json:"extattrs"`
 }
 
 func NewEmptyNetworkView() *NetworkView {
@@ -320,6 +320,57 @@ func NewNetworkContainer(netview, cidr string, isIPv6 bool, comment string, ea E
 	nc.returnFields = []string{"extattrs", "network", "network_view", "comment"}
 
 	return &nc
+}
+
+type NetworkContainerNextAvailable struct {
+	IBBase  `json:"-"`
+	Network *NetworkContainerNextAvailableInfo `json:"network"`
+	Comment string                             `json:"comment"`
+	Ea      EA                                 `json:"extattrs"`
+}
+
+type NetworkContainerNextAvailableInfo struct {
+	Function     string            `json:"_object_function"`
+	ResultField  string            `json:"_result_field"`
+	Object       string            `json:"_object"`
+	ObjectParams map[string]string `json:"_object_parameters"`
+	Params       map[string]uint   `json:"_parameters"`
+	NetviewName  string            `json:"network_view,omitempty"`
+}
+
+func NewNetworkContainerNextAvailableInfo(netview, cidr string, prefixLen uint, isIPv6 bool) *NetworkContainerNextAvailableInfo {
+	containerInfo := NetworkContainerNextAvailableInfo{
+		Function:     "next_available_network",
+		ResultField:  "networks",
+		ObjectParams: map[string]string{"network": cidr},
+		Params:       map[string]uint{"cidr": prefixLen},
+		NetviewName:  netview,
+	}
+
+	if isIPv6 {
+		containerInfo.Object = "ipv6networkcontainer"
+	} else {
+		containerInfo.Object = "networkcontainer"
+	}
+
+	return &containerInfo
+}
+
+func NewNetworkContainerNextAvailable(ncav *NetworkContainerNextAvailableInfo, isIPv6 bool, comment string, ea EA) *NetworkContainerNextAvailable {
+	nc := &NetworkContainerNextAvailable{
+		Network: ncav,
+		Ea:      ea,
+		Comment: comment,
+	}
+
+	if isIPv6 {
+		nc.objectType = "ipv6networkcontainer"
+	} else {
+		nc.objectType = "networkcontainer"
+	}
+	nc.returnFields = []string{"extattrs", "network", "network_view", "comment"}
+
+	return nc
 }
 
 type FixedAddress struct {


### PR DESCRIPTION
Add Allocate Network Container NIOS operation. This is used to dynamically create network containers to be used with infoblox terraform.

Link to Infoblox Terraform Issue.
https://github.com/infobloxopen/terraform-provider-infoblox/issues/157