### PR TITLE
Added NIOS operation to allocate network container

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ This library is compatible with Go 1.2+
 
    * AllocateIP
    * AllocateNetwork
+   * AllocateNetworkContainer
    * CreateARecord
    * CreateAAAARecord
    * CreateZoneAuth

--- a/object_manager.go
+++ b/object_manager.go
@@ -12,6 +12,7 @@ var _ IBObjectManager = new(ObjectManager)
 type IBObjectManager interface {
 	AllocateIP(netview string, cidr string, ipAddr string, isIPv6 bool, macOrDuid string, name string, comment string, eas EA) (*FixedAddress, error)
 	AllocateNetwork(netview string, cidr string, isIPv6 bool, prefixLen uint, comment string, eas EA) (network *Network, err error)
+	AllocateNetworkContainer(netview string, cidr string, isIPv6 bool, prefixLen uint, comment string, eas EA) (network *NetworkContainer, err error)
 	CreateARecord(netView string, dnsView string, name string, cidr string, ipAddr string, ttl uint32, useTTL bool, comment string, ea EA) (*RecordA, error)
 	CreateAAAARecord(netView string, dnsView string, recordName string, cidr string, ipAddr string, useTtl bool, ttl uint32, comment string, eas EA) (*RecordAAAA, error)
 	CreateZoneAuth(fqdn string, ea EA) (*ZoneAuth, error)

--- a/object_manager_network_container.go
+++ b/object_manager_network_container.go
@@ -76,6 +76,33 @@ func (objMgr *ObjectManager) UpdateNetworkContainer(
 	return nc, nil
 }
 
+func (objMgr *ObjectManager) AllocateNetworkContainer(
+	netview string,
+	cidr string,
+	isIPv6 bool,
+	prefixLen uint,
+	comment string,
+	eas EA) (networkContainer *NetworkContainer, err error) {
+
+	containerInfo := NewNetworkContainerNextAvailableInfo(netview, cidr, prefixLen, isIPv6)
+	container := NewNetworkContainerNextAvailable(containerInfo, isIPv6, comment, eas)
+
+	ref, err := objMgr.connector.CreateObject(container)
+	fmt.Println(ref)
+	if err == nil {
+		if isIPv6 {
+			networkContainer, err = BuildIPv6NetworkContainerFromRef(ref)
+		} else {
+			networkContainer, err = BuildNetworkContainerFromRef(ref)
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return
+}
+
 func (objMgr *ObjectManager) DeleteNetworkContainer(ref string) (string, error) {
 	ncRegExp := regexp.MustCompile("^(ipv6)?networkcontainer\\/.+")
 	if !ncRegExp.MatchString(ref) {

--- a/object_manager_network_container.go
+++ b/object_manager_network_container.go
@@ -88,7 +88,7 @@ func (objMgr *ObjectManager) AllocateNetworkContainer(
 	container := NewNetworkContainerNextAvailable(containerInfo, isIPv6, comment, eas)
 
 	ref, err := objMgr.connector.CreateObject(container)
-	fmt.Println(ref)
+
 	if err == nil {
 		if isIPv6 {
 			networkContainer, err = BuildIPv6NetworkContainerFromRef(ref)

--- a/object_manager_network_container_test.go
+++ b/object_manager_network_container_test.go
@@ -451,4 +451,115 @@ var _ = Describe("Object Manager: network container", func() {
 			Expect(err).ToNot(BeNil())
 		})
 	})
+
+	Describe("Allocate Network Container", func() {
+		cmpType := "Docker"
+		tenantID := "01234567890abcdef01234567890abcdef"
+		netviewName := "default_view"
+		cidr := "142.0.22.0/24"
+		prefixLen := uint(28)
+		networkName := "private-net"
+		fakeRefReturn := fmt.Sprintf("networkcontainer/ZG5zLm5ldHdvcmskODkuMC4wLjAvMjQvMjU:%s/%s", cidr, netviewName)
+		ea := EA{"Site": "test"}
+		comment := "Test network container"
+		resObj, err := BuildNetworkContainerFromRef(fakeRefReturn)
+
+		containerInfo := NewNetworkContainerNextAvailableInfo(netviewName, cidr, prefixLen, false)
+		container := NewNetworkContainerNextAvailable(containerInfo, false, comment, ea)
+
+		connector := &fakeConnector{
+			createObjectObj: container,
+			resultObject:    resObj,
+			fakeRefReturn:   fakeRefReturn,
+		}
+
+		objMgr := NewObjectManager(connector, cmpType, tenantID)
+
+		connector.createObjectObj.(*NetworkContainerNextAvailable).Ea = ea
+		connector.createObjectObj.(*NetworkContainerNextAvailable).Ea["Network Name"] = networkName
+
+		var actualNetwork *NetworkContainer
+		It("should pass expected Network Container Object to CreateObject", func() {
+			actualNetwork, err = objMgr.AllocateNetworkContainer(
+				netviewName, cidr, false, prefixLen, comment, ea)
+		})
+		It("should return expected Network Object", func() {
+			Expect(actualNetwork).To(Equal(connector.resultObject))
+			Expect(err).To(BeNil())
+		})
+	})
+
+	Describe("Does not allocate Network Container if an invalid cidr is passed", func() {
+		cmpType := "Docker"
+		tenantID := "01234567890abcdef01234567890abcdef"
+		netviewName := "default_view"
+		cidr := "10.0.1.0./64"
+		prefixLen := uint(65)
+		networkName := "private-net"
+		fakeRefReturn := fmt.Sprintf("networkcontainer/ZG5zLm5ldHdvcmskODkuMC4wLjAvMjQvMjU:%s/%s", cidr, netviewName)
+		ea := EA{"Site": "test"}
+		comment := "Test network container"
+		resObj, err := BuildNetworkContainerFromRef(fakeRefReturn)
+
+		containerInfo := NewNetworkContainerNextAvailableInfo(netviewName, cidr, prefixLen, false)
+		container := NewNetworkContainerNextAvailable(containerInfo, false, comment, ea)
+
+		connector := &fakeConnector{
+			createObjectObj: container,
+			resultObject:    resObj,
+			fakeRefReturn:   fakeRefReturn,
+		}
+
+		objMgr := NewObjectManager(connector, cmpType, tenantID)
+
+		connector.createObjectObj.(*NetworkContainerNextAvailable).Ea = ea
+		connector.createObjectObj.(*NetworkContainerNextAvailable).Ea["Network Name"] = networkName
+
+		var actualNetwork *NetworkContainer
+		It("should pass expected Network Container Object with invalid Cidr value to CreateObject", func() {
+			actualNetwork, err = objMgr.AllocateNetworkContainer(
+				netviewName, cidr, false, prefixLen, comment, ea)
+		})
+		It("should return nil and an error message", func() {
+			Expect(actualNetwork).To(Equal(connector.resultObject))
+			Expect(err).To(Equal(fmt.Errorf("CIDR format not matched")))
+		})
+	})
+
+	Describe("Allocate Network Container", func() {
+		cmpType := "Docker"
+		tenantID := "01234567890abcdef01234567890abcdef"
+		netviewName := "default_view"
+		cidr := "2003:db8:abcd:14::/64"
+		prefixLen := uint(28)
+		networkName := "private-net"
+		fakeRefReturn := fmt.Sprintf("ipv6networkcontainer/ZG5zLm5ldHdvcmskODkuMC4wLjAvMjQvMjU:%s/%s", cidr, netviewName)
+		ea := EA{"Site": "test"}
+		comment := "Test network container"
+		resObj, err := BuildIPv6NetworkContainerFromRef(fakeRefReturn)
+		fmt.Println(resObj)
+		containerInfo := NewNetworkContainerNextAvailableInfo(netviewName, cidr, prefixLen, true)
+		container := NewNetworkContainerNextAvailable(containerInfo, true, comment, ea)
+
+		connector := &fakeConnector{
+			createObjectObj: container,
+			resultObject:    resObj,
+			fakeRefReturn:   fakeRefReturn,
+		}
+
+		objMgr := NewObjectManager(connector, cmpType, tenantID)
+
+		connector.createObjectObj.(*NetworkContainerNextAvailable).Ea = ea
+		connector.createObjectObj.(*NetworkContainerNextAvailable).Ea["Network Name"] = networkName
+
+		var actualNetwork *NetworkContainer
+		It("should pass expected Network Container Object to CreateObject", func() {
+			actualNetwork, err = objMgr.AllocateNetworkContainer(
+				netviewName, cidr, true, prefixLen, comment, ea)
+		})
+		It("should return expected Network Object", func() {
+			Expect(actualNetwork).To(Equal(connector.resultObject))
+			Expect(err).To(BeNil())
+		})
+	})
 })

--- a/objects.go
+++ b/objects.go
@@ -322,6 +322,57 @@ func NewNetworkContainer(netview, cidr string, isIPv6 bool, comment string, ea E
 	return &nc
 }
 
+type NetworkContainerNextAvailable struct {
+	IBBase  `json:"-"`
+	Network *NetworkContainerNextAvailableInfo `json:"network"`
+	Comment string                             `json:"comment"`
+	Ea      EA                                 `json:"extattrs"`
+}
+
+type NetworkContainerNextAvailableInfo struct {
+	Function     string            `json:"_object_function"`
+	ResultField  string            `json:"_result_field"`
+	Object       string            `json:"_object"`
+	ObjectParams map[string]string `json:"_object_parameters"`
+	Params       map[string]uint   `json:"_parameters"`
+	NetviewName  string            `json:"network_view,omitempty"`
+}
+
+func NewNetworkContainerNextAvailableInfo(netview, cidr string, prefixLen uint, isIPv6 bool) *NetworkContainerNextAvailableInfo {
+	containerInfo := NetworkContainerNextAvailableInfo{
+		Function:     "next_available_network",
+		ResultField:  "networks",
+		ObjectParams: map[string]string{"network": cidr},
+		Params:       map[string]uint{"cidr": prefixLen},
+		NetviewName:  netview,
+	}
+
+	if isIPv6 {
+		containerInfo.Object = "ipv6networkcontainer"
+	} else {
+		containerInfo.Object = "networkcontainer"
+	}
+
+	return &containerInfo
+}
+
+func NewNetworkContainerNextAvailable(ncav *NetworkContainerNextAvailableInfo, isIPv6 bool, comment string, ea EA) *NetworkContainerNextAvailable {
+	nc := &NetworkContainerNextAvailable{
+		Network: ncav,
+		Ea:      ea,
+		Comment: comment,
+	}
+
+	if isIPv6 {
+		nc.objectType = "ipv6networkcontainer"
+	} else {
+		nc.objectType = "networkcontainer"
+	}
+	nc.returnFields = []string{"extattrs", "network", "network_view", "comment"}
+
+	return nc
+}
+
 type FixedAddress struct {
 	IBBase      `json:"-"`
 	Ref         string `json:"_ref,omitempty"`
@@ -604,7 +655,7 @@ type HostRecordIpv4Addr struct {
 	IBBase     `json:"-"`
 	Ipv4Addr   string `json:"ipv4addr,omitempty"`
 	Ref        string `json:"_ref,omitempty"`
-	Mac        string `json:"mac"`
+	Mac        string `json:"mac,omitempty"`
 	View       string `json:"view,omitempty"`
 	Cidr       string `json:"network,omitempty"`
 	EnableDhcp bool   `json:"configure_for_dhcp"`
@@ -636,7 +687,7 @@ type HostRecordIpv6Addr struct {
 	IBBase     `json:"-"`
 	Ipv6Addr   string `json:"ipv6addr,omitempty"`
 	Ref        string `json:"_ref,omitempty"`
-	Duid       string `json:"duid"`
+	Duid       string `json:"duid,omitempty"`
 	View       string `json:"view,omitempty"`
 	Cidr       string `json:"network,omitempty"`
 	EnableDhcp bool   `json:"configure_for_dhcp"`

--- a/objects.go
+++ b/objects.go
@@ -655,7 +655,7 @@ type HostRecordIpv4Addr struct {
 	IBBase     `json:"-"`
 	Ipv4Addr   string `json:"ipv4addr,omitempty"`
 	Ref        string `json:"_ref,omitempty"`
-	Mac        string `json:"mac,omitempty"`
+	Mac        string `json:"mac"`
 	View       string `json:"view,omitempty"`
 	Cidr       string `json:"network,omitempty"`
 	EnableDhcp bool   `json:"configure_for_dhcp"`
@@ -687,7 +687,7 @@ type HostRecordIpv6Addr struct {
 	IBBase     `json:"-"`
 	Ipv6Addr   string `json:"ipv6addr,omitempty"`
 	Ref        string `json:"_ref,omitempty"`
-	Duid       string `json:"duid,omitempty"`
+	Duid       string `json:"duid"`
 	View       string `json:"view,omitempty"`
 	Cidr       string `json:"network,omitempty"`
 	EnableDhcp bool   `json:"configure_for_dhcp"`

--- a/utils.go
+++ b/utils.go
@@ -48,6 +48,46 @@ func BuildNetworkFromRef(ref string) (*Network, error) {
 	return newNet, nil
 }
 
+func BuildNetworkContainerFromRef(ref string) (*NetworkContainer, error) {
+	// networkcontainer/ZG5zLm5ldHdvcmskODkuMC4wLjAvMjQvMjU:89.0.0.0/24/global_view
+	r := regexp.MustCompile(`networkcontainer/\w+:(\d+\.\d+\.\d+\.\d+/\d+)/(.+)`)
+	m := r.FindStringSubmatch(ref)
+
+	if m == nil {
+		return nil, fmt.Errorf("CIDR format not matched")
+	}
+
+	newNet := NewNetworkContainer(m[2], m[1], false, "", nil)
+	newNet.Ref = ref
+	return newNet, nil
+}
+
+func BuildIPv6NetworkContainerFromRef(ref string) (*NetworkContainer, error) {
+	// ipv6networkcontainer/ZG5zLm5ldHdvcmskODkuMC4wLjAvMjQvMjU:2001%3Adb8%3Aabcd%3A0012%3A%3A0/64/global_view
+	r := regexp.MustCompile(`ipv6networkcontainer/[^:]+:(([^\/]+)\/\d+)\/(.+)`)
+	m := r.FindStringSubmatch(ref)
+
+	if m == nil {
+		return nil, fmt.Errorf("CIDR format not matched")
+	}
+
+	cidr, err := url.QueryUnescape(m[1])
+	if err != nil {
+		return nil, fmt.Errorf(
+			"cannot extract network CIDR information from the reference '%s': %s",
+			ref, err.Error())
+	}
+
+	if _, _, err = net.ParseCIDR(cidr); err != nil {
+		return nil, fmt.Errorf("CIDR format not matched")
+	}
+
+	newNet := NewNetworkContainer(m[3], cidr, true, "", nil)
+	newNet.Ref = ref
+
+	return newNet, nil
+}
+
 func GetIPAddressFromRef(ref string) string {
 	// fixedaddress/ZG5zLmJpbmRfY25h:12.0.10.1/external
 	r := regexp.MustCompile(`fixedaddress/\w+:(\d+\.\d+\.\d+\.\d+)/.+`)


### PR DESCRIPTION
Add Allocate Network Container NIOS operation. This is used to dynamically create network containers to be used with infoblox terraform.

Link to Infoblox Terraform Issue.
infobloxopen/terraform-provider-infoblox#157