### PR TITLE
Clarified the error messages returned by the tls.X509KeyPair function

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -147,7 +147,7 @@ func (whr *WapiHttpRequestor) Init(authCfg AuthConfig, trCfg TransportConfig) {
 	if authCfg.ClientKey != nil && authCfg.ClientCert != nil {
 		cert, err := tls.X509KeyPair(authCfg.ClientCert, authCfg.ClientKey)
 		if err != nil {
-			log.Fatal(err)
+			log.Fatal("Invalid certificate key pair: ", err)
 		}
 
 		certList = []tls.Certificate{cert}

--- a/connector.go
+++ b/connector.go
@@ -147,7 +147,7 @@ func (whr *WapiHttpRequestor) Init(authCfg AuthConfig, trCfg TransportConfig) {
 	if authCfg.ClientKey != nil && authCfg.ClientCert != nil {
 		cert, err := tls.X509KeyPair(authCfg.ClientCert, authCfg.ClientKey)
 		if err != nil {
-			log.Fatal("Invalid certificate key pair: ", err)
+			log.Fatal("Invalid certificate key pair (PEM format error): ", err)
 		}
 
 		certList = []tls.Certificate{cert}


### PR DESCRIPTION
# Issue/Feature description

* The messages returned by the `tls.X509KeyPair` function call were not clear for a user.

* Related to the ticket `NIOS-84878`.

# How it was fixed/implemented

* Supplemented error messages returned by tls.X509KeyPair function call
  with "Invalid certificate key pair:" prefix.

# Reviewers

@skudriavtsev 