### PR TITLE
Add useful fields for Authoritative Zone resource

### DIFF
--- a/object_manager.go
+++ b/object_manager.go
@@ -15,7 +15,7 @@ type IBObjectManager interface {
 	AllocateNetworkContainer(netview string, cidr string, isIPv6 bool, prefixLen uint, comment string, eas EA) (netContainer *NetworkContainer, err error)
 	CreateARecord(netView string, dnsView string, name string, cidr string, ipAddr string, ttl uint32, useTTL bool, comment string, ea EA) (*RecordA, error)
 	CreateAAAARecord(netView string, dnsView string, recordName string, cidr string, ipAddr string, useTtl bool, ttl uint32, comment string, eas EA) (*RecordAAAA, error)
-	CreateZoneAuth(fqdn string, nsGroup string, restartIfNeeded bool, comment string, SoaDefaultTtl int, SoaExpire int, SoaNegativeTtl int, SoaRefresh int, SoaRetry int, ea EA) (*ZoneAuth, error)
+	CreateZoneAuth(dnsview string, fqdn string, nsGroup string, restartIfNeeded bool, comment string, soaDefaultTtl int, soaExpire int, soaNegativeTtl int, soaRefresh int, soaRetry int, zoneFormat string, ea EA) (*ZoneAuth, error)
 	CreateCNAMERecord(dnsview string, canonical string, recordname string, useTtl bool, ttl uint32, comment string, eas EA) (*RecordCNAME, error)
 	CreateDefaultNetviews(globalNetview string, localNetview string) (globalNetviewRef string, localNetviewRef string, err error)
 	CreateEADefinition(eadef EADefinition) (*EADefinition, error)
@@ -79,6 +79,7 @@ type IBObjectManager interface {
 	UpdatePTRRecord(ref string, netview string, ptrdname string, name string, cidr string, ipAddr string, useTtl bool, ttl uint32, comment string, setEas EA) (*RecordPTR, error)
 	UpdateTXTRecord(ref string, recordName string, text string, ttl uint32, useTtl bool, comment string, eas EA) (*RecordTXT, error)
 	UpdateARecord(ref string, name string, ipAddr string, cidr string, netview string, ttl uint32, useTTL bool, comment string, eas EA) (*RecordA, error)
+	UpdateZoneAuth(ref string, dnsview string, nsGroup string, restartIfNeeded bool, comment string, soaDefaultTtl int, soaExpire int, soaNegativeTtl int, soaRefresh int, soaRetry int, ea EA) (*ZoneAuth, error)
 	UpdateZoneDelegated(ref string, delegate_to []NameServer) (*ZoneDelegated, error)
 }
 

--- a/object_manager.go
+++ b/object_manager.go
@@ -15,7 +15,7 @@ type IBObjectManager interface {
 	AllocateNetworkContainer(netview string, cidr string, isIPv6 bool, prefixLen uint, comment string, eas EA) (netContainer *NetworkContainer, err error)
 	CreateARecord(netView string, dnsView string, name string, cidr string, ipAddr string, ttl uint32, useTTL bool, comment string, ea EA) (*RecordA, error)
 	CreateAAAARecord(netView string, dnsView string, recordName string, cidr string, ipAddr string, useTtl bool, ttl uint32, comment string, eas EA) (*RecordAAAA, error)
-	CreateZoneAuth(fqdn string, ea EA) (*ZoneAuth, error)
+	CreateZoneAuth(fqdn string, nsGroup string, restartIfNeeded bool, comment string, SoaDefaultTtl int, SoaExpire int, SoaNegativeTtl int, SoaRefresh int, SoaRetry int, ea EA) (*ZoneAuth, error)
 	CreateCNAMERecord(dnsview string, canonical string, recordname string, useTtl bool, ttl uint32, comment string, eas EA) (*RecordCNAME, error)
 	CreateDefaultNetviews(globalNetview string, localNetview string) (globalNetviewRef string, localNetviewRef string, err error)
 	CreateEADefinition(eadef EADefinition) (*EADefinition, error)
@@ -192,38 +192,6 @@ func (objMgr *ObjectManager) GetGridInfo() ([]Grid, error) {
 	err := objMgr.connector.GetObject(
 		gridObj, "", NewQueryParams(false, nil), &res)
 	return res, err
-}
-
-// CreateZoneAuth creates zones and subs by passing fqdn
-func (objMgr *ObjectManager) CreateZoneAuth(
-	fqdn string,
-	eas EA) (*ZoneAuth, error) {
-
-	zoneAuth := NewZoneAuth(ZoneAuth{
-		Fqdn: fqdn,
-		Ea:   eas})
-
-	ref, err := objMgr.connector.CreateObject(zoneAuth)
-	zoneAuth.Ref = ref
-	return zoneAuth, err
-}
-
-// Retreive a authortative zone by ref
-func (objMgr *ObjectManager) GetZoneAuthByRef(ref string) (*ZoneAuth, error) {
-	res := NewZoneAuth(ZoneAuth{})
-
-	if ref == "" {
-		return nil, fmt.Errorf("empty reference to an object is not allowed")
-	}
-
-	err := objMgr.connector.GetObject(
-		res, ref, NewQueryParams(false, nil), res)
-	return res, err
-}
-
-// DeleteZoneAuth deletes an auth zone
-func (objMgr *ObjectManager) DeleteZoneAuth(ref string) (string, error) {
-	return objMgr.connector.DeleteObject(ref)
 }
 
 // GetZoneAuth returns the authoritatives zones

--- a/object_manager_test.go
+++ b/object_manager_test.go
@@ -310,6 +310,7 @@ var _ = Describe("Object Manager", func() {
 	Describe("Create Zone Auth", func() {
 		cmpType := "Docker"
 		tenantID := "01234567890abcdef01234567890abcdef"
+		dnsview := "default"
 		nsGroup := "mynameservers"
 		restartIfNeeded := true
 		fqdn := "azone.example.com"
@@ -319,12 +320,13 @@ var _ = Describe("Object Manager", func() {
 		soaNegativeTtl := 900
 		soaRefresh := 10800
 		soaRetry := 3600
+		zoneFormat := "FORWARD"
 		fakeRefReturn := "zone_auth/ZG5zLnpvbmUkLl9kZWZhdWx0LnphLmNvLmFic2EuY2Fhcy5vaG15Z2xiLmdzbGJpYmNsaWVudA:dzone.example.com/default"
 		zaFakeConnector := &fakeConnector{
-			createObjectObj: NewZoneAuth(ZoneAuth{Fqdn: fqdn, NsGroup: nsGroup, RestartIfNeeded: restartIfNeeded, Comment: comment,
-				SoaDefaultTtl: soaDefaultTtl, SoaExpire: soaExpire, SoaNegativeTtl: soaNegativeTtl, SoaRefresh: soaRefresh, SoaRetry: soaRetry}),
-			resultObject: NewZoneAuth(ZoneAuth{Fqdn: fqdn, NsGroup: nsGroup, RestartIfNeeded: restartIfNeeded, Comment: comment,
-				SoaDefaultTtl: soaDefaultTtl, SoaExpire: soaExpire, SoaNegativeTtl: soaNegativeTtl, SoaRefresh: soaRefresh, SoaRetry: soaRetry, Ref: fakeRefReturn}),
+			createObjectObj: NewZoneAuth(ZoneAuth{View: dnsview, Fqdn: fqdn, NsGroup: nsGroup, RestartIfNeeded: restartIfNeeded, Comment: comment,
+				SoaDefaultTtl: soaDefaultTtl, SoaExpire: soaExpire, SoaNegativeTtl: soaNegativeTtl, SoaRefresh: soaRefresh, SoaRetry: soaRetry, ZoneFormat: zoneFormat}),
+			resultObject: NewZoneAuth(ZoneAuth{View: dnsview, Fqdn: fqdn, NsGroup: nsGroup, RestartIfNeeded: restartIfNeeded, Comment: comment,
+				SoaDefaultTtl: soaDefaultTtl, SoaExpire: soaExpire, SoaNegativeTtl: soaNegativeTtl, SoaRefresh: soaRefresh, SoaRetry: soaRetry, ZoneFormat: zoneFormat, Ref: fakeRefReturn}),
 			fakeRefReturn: fakeRefReturn,
 		}
 
@@ -343,7 +345,7 @@ var _ = Describe("Object Manager", func() {
 		var actualZoneAuth *ZoneAuth
 		var err error
 		It("should pass expected ZoneAuth Object to CreateObject", func() {
-			actualZoneAuth, err = objMgr.CreateZoneAuth(fqdn, nsGroup, restartIfNeeded, comment, soaDefaultTtl, soaExpire, soaNegativeTtl, soaRefresh, soaRetry, ea)
+			actualZoneAuth, err = objMgr.CreateZoneAuth(dnsview, fqdn, nsGroup, restartIfNeeded, comment, soaDefaultTtl, soaExpire, soaNegativeTtl, soaRefresh, soaRetry, zoneFormat, ea)
 		})
 		It("should return expected ZoneAuth Object", func() {
 			Expect(actualZoneAuth).To(Equal(zaFakeConnector.resultObject))
@@ -354,13 +356,14 @@ var _ = Describe("Object Manager", func() {
 	Describe("Get AuthZone by ref", func() {
 		cmpType := "Docker"
 		tenantID := "01234567890abcdef01234567890abcdef"
+		dnsview := "default"
 		fqdn := "azone.example.com"
 		fakeRefReturn := "zone_delegated/ZG5zLnpvbmUkLl9kZWZhdWx0LnphLmNvLmFic2EuY2Fhcy5vaG15Z2xiLmdzbGJpYmNsaWVudA:azone.example.com/default"
 		zdFakeConnector := &fakeConnector{
 			getObjectObj:         NewZoneAuth(ZoneAuth{}),
 			getObjectRef:         fakeRefReturn,
 			getObjectQueryParams: NewQueryParams(false, nil),
-			resultObject:         NewZoneAuth(ZoneAuth{Fqdn: fqdn}),
+			resultObject:         NewZoneAuth(ZoneAuth{View: dnsview, Fqdn: fqdn}),
 		}
 
 		objMgr := NewObjectManager(zdFakeConnector, cmpType, tenantID)
@@ -381,6 +384,45 @@ var _ = Describe("Object Manager", func() {
 			actualZoneAuth, err = objMgr.GetZoneAuthByRef("")
 			Expect(actualZoneAuth).To(Equal(getNoRef))
 			Expect(err).ToNot(BeNil())
+		})
+	})
+
+	Describe("Update ZoneAuth", func() {
+		cmpType := "Docker"
+		tenantID := "01234567890abcdef01234567890abcdef"
+		dnsview := "default"
+		// fqdn := "azone.example.com"
+		nsGroup := "mynameservers"
+		restartIfNeeded := true
+		comment := "test comment"
+		soaDefaultTtl := 3600
+		soaExpire := 2419200
+		soaNegativeTtl := 900
+		soaRefresh := 10800
+		soaRetry := 3600
+		// zoneFormat := "FORWARD"
+		ea := make(EA)
+
+		fakeRefReturn := "zone_auth/ZG5zLnpvbmUkLl9kZWZhdWx0LnphLmNvLmFic2EuY2Fhcy5vaG15Z2xiLmdzbGJpYmNsaWVudA:dzone.example.com/default"
+
+		zaFakeConnector := &fakeConnector{
+			updateObjectObj: NewZoneAuth(ZoneAuth{Ref: fakeRefReturn, View: dnsview, NsGroup: nsGroup, RestartIfNeeded: restartIfNeeded, Comment: comment,
+				SoaDefaultTtl: soaDefaultTtl, SoaExpire: soaExpire, SoaNegativeTtl: soaNegativeTtl, SoaRefresh: soaRefresh, SoaRetry: soaRetry, Ea: ea}),
+			updateObjectRef: fakeRefReturn,
+			resultObject: NewZoneAuth(ZoneAuth{Ref: fakeRefReturn, View: dnsview, NsGroup: nsGroup, RestartIfNeeded: restartIfNeeded, Comment: comment,
+				SoaDefaultTtl: soaDefaultTtl, SoaExpire: soaExpire, SoaNegativeTtl: soaNegativeTtl, SoaRefresh: soaRefresh, SoaRetry: soaRetry, Ea: ea}),
+			fakeRefReturn: fakeRefReturn,
+		}
+
+		objMgr := NewObjectManager(zaFakeConnector, cmpType, tenantID)
+
+		var actualZoneAuth *ZoneAuth
+		var err error
+		It("should pass expected ZoneAuth fields to UpdateObject and receive updated ZoneAuth Object", func() {
+			actualZoneAuth, err = objMgr.UpdateZoneAuth(fakeRefReturn, dnsview, nsGroup, restartIfNeeded, comment,
+				soaDefaultTtl, soaExpire, soaNegativeTtl, soaRefresh, soaRetry, ea)
+			Expect(err).To(BeNil())
+			Expect(actualZoneAuth).To(Equal(zaFakeConnector.resultObject))
 		})
 	})
 

--- a/object_manager_test.go
+++ b/object_manager_test.go
@@ -310,12 +310,22 @@ var _ = Describe("Object Manager", func() {
 	Describe("Create Zone Auth", func() {
 		cmpType := "Docker"
 		tenantID := "01234567890abcdef01234567890abcdef"
+		nsGroup := "mynameservers"
+		restartIfNeeded := true
 		fqdn := "azone.example.com"
+		comment := "test comment"
+		soaDefaultTtl := 3600
+		soaExpire := 2419200
+		soaNegativeTtl := 900
+		soaRefresh := 10800
+		soaRetry := 3600
 		fakeRefReturn := "zone_auth/ZG5zLnpvbmUkLl9kZWZhdWx0LnphLmNvLmFic2EuY2Fhcy5vaG15Z2xiLmdzbGJpYmNsaWVudA:dzone.example.com/default"
 		zaFakeConnector := &fakeConnector{
-			createObjectObj: NewZoneAuth(ZoneAuth{Fqdn: fqdn}),
-			resultObject:    NewZoneAuth(ZoneAuth{Fqdn: fqdn, Ref: fakeRefReturn}),
-			fakeRefReturn:   fakeRefReturn,
+			createObjectObj: NewZoneAuth(ZoneAuth{Fqdn: fqdn, NsGroup: nsGroup, RestartIfNeeded: restartIfNeeded, Comment: comment,
+				SoaDefaultTtl: soaDefaultTtl, SoaExpire: soaExpire, SoaNegativeTtl: soaNegativeTtl, SoaRefresh: soaRefresh, SoaRetry: soaRetry}),
+			resultObject: NewZoneAuth(ZoneAuth{Fqdn: fqdn, NsGroup: nsGroup, RestartIfNeeded: restartIfNeeded, Comment: comment,
+				SoaDefaultTtl: soaDefaultTtl, SoaExpire: soaExpire, SoaNegativeTtl: soaNegativeTtl, SoaRefresh: soaRefresh, SoaRetry: soaRetry, Ref: fakeRefReturn}),
+			fakeRefReturn: fakeRefReturn,
 		}
 
 		objMgr := NewObjectManager(zaFakeConnector, cmpType, tenantID)
@@ -333,7 +343,7 @@ var _ = Describe("Object Manager", func() {
 		var actualZoneAuth *ZoneAuth
 		var err error
 		It("should pass expected ZoneAuth Object to CreateObject", func() {
-			actualZoneAuth, err = objMgr.CreateZoneAuth(fqdn, ea)
+			actualZoneAuth, err = objMgr.CreateZoneAuth(fqdn, nsGroup, restartIfNeeded, comment, soaDefaultTtl, soaExpire, soaNegativeTtl, soaRefresh, soaRetry, ea)
 		})
 		It("should return expected ZoneAuth Object", func() {
 			Expect(actualZoneAuth).To(Equal(zaFakeConnector.resultObject))
@@ -361,7 +371,6 @@ var _ = Describe("Object Manager", func() {
 		It("should pass expected ZoneAuth Object to GetObject", func() {
 			actualZoneAuth, err = objMgr.GetZoneAuthByRef(fakeRefReturn)
 		})
-		fmt.Printf("doodo  %s", actualZoneAuth)
 		It("should return expected ZoneAuth Object", func() {
 			Expect(actualZoneAuth).To(Equal(zdFakeConnector.resultObject))
 			Expect(err).To(BeNil())

--- a/object_manager_zone_auth.go
+++ b/object_manager_zone_auth.go
@@ -1,0 +1,50 @@
+package ibclient
+
+import "fmt"
+
+func (objMgr *ObjectManager) CreateZoneAuth(
+	fqdn string,
+	nsGroup string,
+	restartIfNeeded bool,
+	comment string,
+	soaDefaultTtl int,
+	soaExpire int,
+	soaNegativeTtl int,
+	soaRefresh int,
+	soaRetry int,
+	eas EA) (*ZoneAuth, error) {
+
+	zoneAuth := NewZoneAuth(ZoneAuth{
+		Fqdn:            fqdn,
+		NsGroup:         nsGroup,
+		RestartIfNeeded: restartIfNeeded,
+		Comment:         comment,
+		SoaDefaultTtl:   soaDefaultTtl,
+		SoaExpire:       soaExpire,
+		SoaNegativeTtl:  soaNegativeTtl,
+		SoaRefresh:      soaRefresh,
+		SoaRetry:        soaRetry,
+		Ea:              eas})
+
+	ref, err := objMgr.connector.CreateObject(zoneAuth)
+	zoneAuth.Ref = ref
+	return zoneAuth, err
+}
+
+// Retreive a authortative zone by ref
+func (objMgr *ObjectManager) GetZoneAuthByRef(ref string) (*ZoneAuth, error) {
+	res := NewZoneAuth(ZoneAuth{})
+
+	if ref == "" {
+		return nil, fmt.Errorf("empty reference to an object is not allowed")
+	}
+
+	err := objMgr.connector.GetObject(
+		res, ref, NewQueryParams(false, nil), res)
+	return res, err
+}
+
+// DeleteZoneAuth deletes an auth zone
+func (objMgr *ObjectManager) DeleteZoneAuth(ref string) (string, error) {
+	return objMgr.connector.DeleteObject(ref)
+}

--- a/objects.go
+++ b/objects.go
@@ -827,7 +827,7 @@ type ZoneAuth struct {
 	IBBase          `json:"-"`
 	Ref             string `json:"_ref,omitempty"`
 	Fqdn            string `json:"fqdn,omitempty"`
-	View            string `json:"view,omitempty"`
+	View            string `json:"view"`
 	NsGroup         string `json:"ns_group,omitempty"`
 	RestartIfNeeded bool   `json:"restart_if_needed"`
 	Comment         string `json:"comment"`
@@ -836,6 +836,7 @@ type ZoneAuth struct {
 	SoaNegativeTtl  int    `json:"soa_negative_ttl"`
 	SoaRefresh      int    `json:"soa_refresh"`
 	SoaRetry        int    `json:"soa_retry"`
+	ZoneFormat      string `json:"zone_format,omitempty"`
 	Ea              EA     `json:"extattrs"`
 }
 
@@ -844,8 +845,9 @@ func NewZoneAuth(za ZoneAuth) *ZoneAuth {
 	res.objectType = "zone_auth"
 	// restart_if_needed not included here because it is not readable
 	res.returnFields = []string{
-		"extattrs", "fqdn", "view", "ns_group", "comment",
+		"view", "fqdn", "ns_group", "comment",
 		"soa_default_ttl", "soa_expire", "soa_negative_ttl", "soa_refresh", "soa_retry",
+		"zone_format", "extattrs",
 	}
 
 	return &res

--- a/objects.go
+++ b/objects.go
@@ -824,17 +824,29 @@ func NewRecordTXT(
 }
 
 type ZoneAuth struct {
-	IBBase `json:"-"`
-	Ref    string `json:"_ref,omitempty"`
-	Fqdn   string `json:"fqdn,omitempty"`
-	View   string `json:"view,omitempty"`
-	Ea     EA     `json:"extattrs"`
+	IBBase          `json:"-"`
+	Ref             string `json:"_ref,omitempty"`
+	Fqdn            string `json:"fqdn,omitempty"`
+	View            string `json:"view,omitempty"`
+	NsGroup         string `json:"ns_group,omitempty"`
+	RestartIfNeeded bool   `json:"restart_if_needed"`
+	Comment         string `json:"comment"`
+	SoaDefaultTtl   int    `json:"soa_default_ttl"`
+	SoaExpire       int    `json:"soa_expire"`
+	SoaNegativeTtl  int    `json:"soa_negative_ttl"`
+	SoaRefresh      int    `json:"soa_refresh"`
+	SoaRetry        int    `json:"soa_retry"`
+	Ea              EA     `json:"extattrs"`
 }
 
 func NewZoneAuth(za ZoneAuth) *ZoneAuth {
 	res := za
 	res.objectType = "zone_auth"
-	res.returnFields = []string{"extattrs", "fqdn", "view"}
+	// restart_if_needed not included here because it is not readable
+	res.returnFields = []string{
+		"extattrs", "fqdn", "view", "ns_group", "comment",
+		"soa_default_ttl", "soa_expire", "soa_negative_ttl", "soa_refresh", "soa_retry",
+	}
 
 	return &res
 }

--- a/objects_test.go
+++ b/objects_test.go
@@ -637,6 +637,7 @@ var _ = Describe("Objects", func() {
 			soa_negative_ttl := 900
 			soa_refresh := 10800
 			soa_retry := 3600
+			zone_format := "FORWARD"
 			view := "default"
 
 			za := NewZoneAuth(ZoneAuth{
@@ -649,9 +650,11 @@ var _ = Describe("Objects", func() {
 				SoaNegativeTtl:  soa_negative_ttl,
 				SoaRefresh:      soa_refresh,
 				SoaRetry:        soa_retry,
+				ZoneFormat:      zone_format,
 				View:            view})
 
 			It("should set fields correctly", func() {
+				Expect(za.View).To(Equal(view))
 				Expect(za.Fqdn).To(Equal(fqdn))
 				Expect(za.NsGroup).To(Equal(ns_group))
 				Expect(za.RestartIfNeeded).To(Equal(restart_if_needed))
@@ -661,6 +664,7 @@ var _ = Describe("Objects", func() {
 				Expect(za.SoaNegativeTtl).To(Equal(soa_negative_ttl))
 				Expect(za.SoaRefresh).To(Equal(soa_refresh))
 				Expect(za.SoaRetry).To(Equal(soa_retry))
+				Expect(za.ZoneFormat).To(Equal(zone_format))
 				Expect(za.View).To(Equal(view))
 			})
 
@@ -668,7 +672,7 @@ var _ = Describe("Objects", func() {
 				Expect(za.ObjectType()).To(Equal("zone_auth"))
 				Expect(za.ReturnFields()).To(ConsistOf(
 					"extattrs", "fqdn", "view", "ns_group", "comment",
-					"soa_default_ttl", "soa_expire", "soa_negative_ttl", "soa_refresh", "soa_retry",
+					"soa_default_ttl", "soa_expire", "soa_negative_ttl", "soa_refresh", "soa_retry", "zone_format",
 				))
 			})
 		})

--- a/objects_test.go
+++ b/objects_test.go
@@ -2,6 +2,7 @@ package ibclient
 
 import (
 	"encoding/json"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -628,20 +629,47 @@ var _ = Describe("Objects", func() {
 
 		Context("ZoneAuth object", func() {
 			fqdn := "domain.com"
+			ns_group := "mynameservers"
+			restart_if_needed := true
+			comment := "test comment"
+			soa_default_ttl := 3600
+			soa_expire := 2419200
+			soa_negative_ttl := 900
+			soa_refresh := 10800
+			soa_retry := 3600
 			view := "default"
 
 			za := NewZoneAuth(ZoneAuth{
-				Fqdn: fqdn,
-				View: view})
+				Fqdn:            fqdn,
+				NsGroup:         ns_group,
+				RestartIfNeeded: restart_if_needed,
+				Comment:         comment,
+				SoaDefaultTtl:   soa_default_ttl,
+				SoaExpire:       soa_expire,
+				SoaNegativeTtl:  soa_negative_ttl,
+				SoaRefresh:      soa_refresh,
+				SoaRetry:        soa_retry,
+				View:            view})
 
 			It("should set fields correctly", func() {
 				Expect(za.Fqdn).To(Equal(fqdn))
+				Expect(za.NsGroup).To(Equal(ns_group))
+				Expect(za.RestartIfNeeded).To(Equal(restart_if_needed))
+				Expect(za.Comment).To(Equal(comment))
+				Expect(za.SoaDefaultTtl).To(Equal(soa_default_ttl))
+				Expect(za.SoaExpire).To(Equal(soa_expire))
+				Expect(za.SoaNegativeTtl).To(Equal(soa_negative_ttl))
+				Expect(za.SoaRefresh).To(Equal(soa_refresh))
+				Expect(za.SoaRetry).To(Equal(soa_retry))
 				Expect(za.View).To(Equal(view))
 			})
 
 			It("should set base fields correctly", func() {
 				Expect(za.ObjectType()).To(Equal("zone_auth"))
-				Expect(za.ReturnFields()).To(ConsistOf("extattrs", "fqdn", "view"))
+				Expect(za.ReturnFields()).To(ConsistOf(
+					"extattrs", "fqdn", "view", "ns_group", "comment",
+					"soa_default_ttl", "soa_expire", "soa_negative_ttl", "soa_refresh", "soa_retry",
+				))
 			})
 		})
 


### PR DESCRIPTION
Fixes #185.

This adds the following fields for the `ZoneAuth` resource, so users can set a Nameserver Group or SOA TTLs when creating a new zone.

* `ns_group`
* `restart_if_needed`
* `comment`
* `soa_default_ttl`
* `soa_expire`
* `soa_negative_ttl`
* `soa_refresh`
* `soa_retry`

These are already present in the Infoblox NIOS API; this change exposes them here in the Go Client.