### PR TITLE
Make certPool public field of TransportConfig

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -35,7 +35,7 @@ type HostConfig struct {
 
 type TransportConfig struct {
 	SslVerify           bool
-	certPool            *x509.CertPool
+	CertPool            *x509.CertPool
 	HttpRequestTimeout  time.Duration // in seconds
 	HttpPoolConnections int
 	ProxyUrl            *url.URL
@@ -58,7 +58,7 @@ func NewTransportConfig(sslVerify string, httpRequestTimeout int, httpPoolConnec
 			err = fmt.Errorf("cannot append certificate from file '%s'", sslVerify)
 			return
 		}
-		cfg.certPool = caPool
+		cfg.CertPool = caPool
 		cfg.SslVerify = true
 	}
 
@@ -155,7 +155,7 @@ func (whr *WapiHttpRequestor) Init(authCfg AuthConfig, trCfg TransportConfig) {
 
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{
-			RootCAs:            trCfg.certPool,
+			RootCAs:            trCfg.CertPool,
 			ClientAuth:         clientAuthType,
 			Certificates:       certList,
 			InsecureSkipVerify: !trCfg.SslVerify,


### PR DESCRIPTION
All fields of the `TransportConfig` are public, but the certPool field is not.
It should not be required to provide a cert pool from a file, but just by providing an existing CertPool object.