### PR TITLE
Renamed SearchHostRecordByAltId more generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ This library is compatible with Go 1.2+
    * GetFixedAddressByRef
    * GetHostRecord
    * GetHostRecordByRef
-   * SearchHostRecordByAltId
+   * GetHostRecordByAltId
    * GetIpAddressFromHostRecord
    * GetNetwork
    * GetNetworkByRef

--- a/object_manager.go
+++ b/object_manager.go
@@ -49,7 +49,7 @@ type IBObjectManager interface {
 	GetFixedAddress(netview string, cidr string, ipAddr string, isIPv6 bool, macOrDuid string) (*FixedAddress, error)
 	GetFixedAddressByRef(ref string) (*FixedAddress, error)
 	GetHostRecord(netview string, dnsview string, recordName string, ipv4addr string, ipv6addr string) (*HostRecord, error)
-	SearchHostRecordByAltId(internalId string, ref string, eaNameForInternalId string) (*HostRecord, error)
+	GetHostRecordByAltId(internalId string, ref string, eaNameForInternalId string) (*HostRecord, error)
 	GetHostRecordByRef(ref string) (*HostRecord, error)
 	GetIpAddressFromHostRecord(host HostRecord) (string, error)
 	GetNetwork(netview string, cidr string, isIPv6 bool, ea EA) (*Network, error)

--- a/object_manager_host_record.go
+++ b/object_manager_host_record.go
@@ -75,7 +75,7 @@ func (objMgr *ObjectManager) GetHostRecordByRef(ref string) (*HostRecord, error)
 	return recordHost, err
 }
 
-func (objMgr *ObjectManager) SearchHostRecordByAltId(
+func (objMgr *ObjectManager) GetHostRecordByAltId(
 	internalId string, ref string, eaNameForInternalId string) (*HostRecord, error) {
 
 	if internalId == "" {


### PR DESCRIPTION
These are changes for making the method SearchHostRecordByAltId more generic like other methods. So that usage of method would be more clear and suitable