### PR TITLE
Adds search for a records by zone name

### DIFF
--- a/object_manager.go
+++ b/object_manager.go
@@ -41,6 +41,7 @@ type IBObjectManager interface {
 	DeleteZoneDelegated(ref string) (string, error)
 	GetARecordByRef(ref string) (*RecordA, error)
 	GetARecord(dnsview string, recordName string, ipAddr string) (*RecordA, error)
+	GetARecordByZone(zone_name string, dnsview string) (*[]RecordA, error)
 	GetAAAARecord(dnsview string, recordName string, ipAddr string) (*RecordAAAA, error)
 	GetAAAARecordByRef(ref string) (*RecordAAAA, error)
 	GetCNAMERecord(dnsview string, canonical string, recordName string) (*RecordCNAME, error)

--- a/object_manager_a-record.go
+++ b/object_manager_a-record.go
@@ -161,6 +161,32 @@ func (objMgr *ObjectManager) GetARecordByRef(ref string) (*RecordA, error) {
 	return recordA, err
 }
 
+func (objMgr *ObjectManager) GetARecordByZone(zone_name string, dnsview string) (*[]RecordA, error) {
+	var res []RecordA
+	recordA := NewEmptyRecordA()
+
+	if dnsview == "" {
+		dnsview = "default"
+	}
+
+	if zone_name == "" {
+		return nil, fmt.Errorf("zone_name must not be empty")
+	}
+
+	sf := map[string]string{
+		"zone": zone_name,
+		"view": dnsview,
+	}
+	queryParams := NewQueryParams(false, sf)
+	err := objMgr.connector.GetObject(recordA, "", queryParams, &res)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &res, nil
+}
+
 func (objMgr *ObjectManager) DeleteARecord(ref string) (string, error) {
 	return objMgr.connector.DeleteObject(ref)
 }


### PR DESCRIPTION
This PR consists of method included with GetARecordByZone, this works when a zone name with dns view is passed  returns list of A records associated with that zone name