### PR TITLE
Adds condition for 'name' parameter in A record for uppercase letters

### DIFF
--- a/object_manager_a-record.go
+++ b/object_manager_a-record.go
@@ -23,6 +23,10 @@ func (objMgr *ObjectManager) CreateARecord(
 			"'name' argument is expected to be non-empty and it must NOT contain leading/trailing spaces")
 	}
 
+	if name != strings.ToLower(name) {
+		return nil, fmt.Errorf("'name' argument is not expected to contain any uppercase letters")
+	}
+
 	recordA := NewRecordA(dnsView, "", name, "", ttl, useTTL, comment, eas, "")
 
 	if ipAddr == "" {
@@ -80,6 +84,10 @@ func (objMgr *ObjectManager) UpdateARecord(
 	if cleanName == "" || cleanName != name {
 		return nil, fmt.Errorf(
 			"'name' argument is expected to be non-empty and it must NOT contain leading/trailing spaces")
+	}
+
+	if name != strings.ToLower(name) {
+		return nil, fmt.Errorf("'name' argument is not expected to contain any uppercase letters")
 	}
 
 	rec, err := objMgr.GetARecordByRef(ref)


### PR DESCRIPTION
This PR just adds the condition for A Record, if any uppercase letters exists in the 'name' parameter value. As NIOS internally converts the uppercase letters to lower case, hence to maintain consistency with NIOS and plugin, this changes are being made.