### PR TITLE
Fixes usage of uppercase letters in FQDN for AAAA-Record

### DIFF
--- a/object_manager_aaaa-record.go
+++ b/object_manager_aaaa-record.go
@@ -17,7 +17,7 @@ func (objMgr *ObjectManager) CreateAAAARecord(
 	comment string,
 	eas EA) (*RecordAAAA, error) {
 
-	cleanName := strings.ToLower(strings.TrimSpace(recordName))
+	cleanName := strings.TrimSpace(recordName)
 	if cleanName == "" || cleanName != recordName {
 		return nil, fmt.Errorf(
 			"'name' argument is expected to be non-empty and it must NOT contain leading/trailing spaces")
@@ -107,7 +107,7 @@ func (objMgr *ObjectManager) UpdateAAAARecord(
 	comment string,
 	setEas EA) (*RecordAAAA, error) {
 
-	cleanName := strings.ToLower(strings.TrimSpace(recordName))
+	cleanName := strings.TrimSpace(recordName)
 	if cleanName == "" || cleanName != recordName {
 		return nil, fmt.Errorf(
 			"'name' argument is expected to be non-empty and it must NOT contain leading/trailing spaces")


### PR DESCRIPTION
This is removes unnecessary restriction,  for not allowing uppercase letters in FQDN for AAAA Record.