### PR TITLE
Update HostConfig with Scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ This library is compatible with Go 1.2+
 
        func main() {
          hostConfig := ibclient.HostConfig{
+            Scheme:  "https",
          	Host:    "<NIOS grid IP>",
             Version: "<WAPI version>",
             Port:    "PORT",

--- a/connector.go
+++ b/connector.go
@@ -28,6 +28,7 @@ type AuthConfig struct {
 }
 
 type HostConfig struct {
+	Scheme  string
 	Host    string
 	Version string
 	Port    string
@@ -250,8 +251,12 @@ func (wrb *WapiRequestBuilder) BuildUrl(t RequestType, objType string, ref strin
 		qry = vals.Encode()
 	}
 
+	scheme := "https"
+	if wrb.hostCfg.Scheme != "" {
+		scheme = wrb.hostCfg.Scheme
+	}
 	u := url.URL{
-		Scheme:   "https",
+		Scheme:   scheme,
 		Host:     wrb.hostCfg.Host + ":" + wrb.hostCfg.Port,
 		Path:     strings.Join(path, "/"),
 		RawQuery: qry,

--- a/connector.go
+++ b/connector.go
@@ -252,8 +252,8 @@ func (wrb *WapiRequestBuilder) BuildUrl(t RequestType, objType string, ref strin
 	}
 
 	scheme := "https"
-	if wrb.hostCfg.Scheme != "" {
-		scheme = wrb.hostCfg.Scheme
+	if wrb.hostCfg.Scheme == "http" {
+		scheme = "http"
 	}
 	u := url.URL{
 		Scheme:   scheme,


### PR DESCRIPTION
Updates HostConfig with `Scheme` and use default "https" if Scheme is not "http". 
No breaking changes.

Updates example in Readme to demonstrate that Host is configurable with Scheme.