### PR TITLE
Introduce request builder with headers

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -91,14 +91,9 @@ type WapiRequestBuilderWithHeaders struct {
 	header http.Header
 }
 
-func NewWapiRequestBuilderWithHeaders(hostCfg HostConfig, authCfg AuthConfig, header http.Header) (*WapiRequestBuilderWithHeaders, error) {
-	wrb := WapiRequestBuilder{
-		hostCfg: hostCfg,
-		authCfg: authCfg,
-	}
-
+func NewWapiRequestBuilderWithHeaders(wrb *WapiRequestBuilder, header http.Header) (*WapiRequestBuilderWithHeaders, error) {
 	return &WapiRequestBuilderWithHeaders{
-		HttpRequestBuilder: &wrb,
+		HttpRequestBuilder: wrb,
 		header:             header,
 	}, nil
 }

--- a/connector.go
+++ b/connector.go
@@ -88,15 +88,27 @@ type WapiRequestBuilder struct {
 
 type WapiRequestBuilderWithHeaders struct {
 	HttpRequestBuilder
-	Header http.Header
+	header http.Header
 }
 
-func (requestBuilder *WapiRequestBuilderWithHeaders) BuildRequest(r RequestType, obj IBObject, ref string, queryParams *QueryParams) (req *http.Request, err error) {
-	req, err = requestBuilder.HttpRequestBuilder.BuildRequest(r, obj, ref, queryParams)
+func NewWapiRequestBuilderWithHeaders(hostCfg HostConfig, authCfg AuthConfig, header http.Header) (*WapiRequestBuilderWithHeaders, error) {
+	wrb := WapiRequestBuilder{
+		hostCfg: hostCfg,
+		authCfg: authCfg,
+	}
+
+	return &WapiRequestBuilderWithHeaders{
+		HttpRequestBuilder: &wrb,
+		header:             header,
+	}, nil
+}
+
+func (wrbh *WapiRequestBuilderWithHeaders) BuildRequest(r RequestType, obj IBObject, ref string, queryParams *QueryParams) (req *http.Request, err error) {
+	req, err = wrbh.HttpRequestBuilder.BuildRequest(r, obj, ref, queryParams)
 	if err != nil {
 		return req, err
 	}
-	for h, values := range requestBuilder.Header {
+	for h, values := range wrbh.header {
 		for _, v := range values {
 			req.Header.Add(h, v)
 		}

--- a/connector.go
+++ b/connector.go
@@ -86,6 +86,24 @@ type WapiRequestBuilder struct {
 	authCfg AuthConfig
 }
 
+type WapiRequestBuilderWithHeaders struct {
+	HttpRequestBuilder
+	Header http.Header
+}
+
+func (requestBuilder *WapiRequestBuilderWithHeaders) BuildRequest(r RequestType, obj IBObject, ref string, queryParams *QueryParams) (req *http.Request, err error) {
+	req, err = requestBuilder.HttpRequestBuilder.BuildRequest(r, obj, ref, queryParams)
+	if err != nil {
+		return req, err
+	}
+	for h, values := range requestBuilder.Header {
+		for _, v := range values {
+			req.Header.Add(h, v)
+		}
+	}
+	return req, nil
+}
+
 type WapiHttpRequestor struct {
 	client http.Client
 }

--- a/connector_test.go
+++ b/connector_test.go
@@ -7,10 +7,29 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+func TestHeaderRequestBuilder_BuildRequest(t *testing.T) {
+	header := make(http.Header)
+	header.Add("x", "1")
+	header.Add("y", "2")
+	requestBuilder := &WapiRequestBuilderWithHeaders{
+		HttpRequestBuilder: &WapiRequestBuilder{},
+		Header:             header,
+	}
+	var obj IBObject
+	req, _ := requestBuilder.BuildRequest(GET, obj, "ref", nil)
+
+	for k := range header {
+		if req.Header.Get(k) != header.Get(k) {
+			t.Errorf("Expected header %s to be %s, got %s", k, header.Get(k), req.Header.Get(k))
+		}
+	}
+}
 
 type FakeRequestBuilder struct {
 	hostCfg HostConfig

--- a/connector_test.go
+++ b/connector_test.go
@@ -7,29 +7,10 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
-
-func TestHeaderRequestBuilder_BuildRequest(t *testing.T) {
-	header := make(http.Header)
-	header.Add("x", "1")
-	header.Add("y", "2")
-	requestBuilder := &WapiRequestBuilderWithHeaders{
-		HttpRequestBuilder: &WapiRequestBuilder{},
-		Header:             header,
-	}
-	var obj IBObject
-	req, _ := requestBuilder.BuildRequest(GET, obj, "ref", nil)
-
-	for k := range header {
-		if req.Header.Get(k) != header.Get(k) {
-			t.Errorf("Expected header %s to be %s, got %s", k, header.Get(k), req.Header.Get(k))
-		}
-	}
-}
 
 type FakeRequestBuilder struct {
 	hostCfg HostConfig
@@ -291,6 +272,42 @@ var _ = Describe("Connector", func() {
 				})
 			})
 
+		})
+	})
+
+	Describe("WapiRequestBuilderWithHeaders", func() {
+		host := "172.22.18.66"
+		version := "2.2"
+		port := "443"
+		username := "myname"
+		password := "mysecrete!"
+		hostCfg := HostConfig{
+			Host:    host,
+			Version: version,
+			Port:    port,
+		}
+		authCfg := AuthConfig{
+			Username: username,
+			Password: password,
+		}
+
+		header := make(http.Header)
+		header.Add("x", "1")
+		header.Add("y", "2")
+
+		wrb, err := NewWapiRequestBuilderWithHeaders(hostCfg, authCfg, header)
+		if err != nil {
+			panic("NewWapiRequestBuilderWithHeaders() is not expected to return an error")
+		}
+
+		Describe("BuildRequest", func() {
+			It("should set given headers to request", func() {
+				var obj IBObject
+				req, _ := wrb.BuildRequest(GET, obj, "ref", nil)
+				for k := range header {
+					Expect(header.Get(k)).To(Equal(req.Header.Get(k)))
+				}
+			})
 		})
 	})
 

--- a/connector_test.go
+++ b/connector_test.go
@@ -295,7 +295,8 @@ var _ = Describe("Connector", func() {
 		header.Add("x", "1")
 		header.Add("y", "2")
 
-		wrb, err := NewWapiRequestBuilderWithHeaders(hostCfg, authCfg, header)
+		wrb, _ := NewWapiRequestBuilder(hostCfg, authCfg)
+		wrbh, err := NewWapiRequestBuilderWithHeaders(wrb, header)
 		if err != nil {
 			panic("NewWapiRequestBuilderWithHeaders() is not expected to return an error")
 		}
@@ -303,7 +304,7 @@ var _ = Describe("Connector", func() {
 		Describe("BuildRequest", func() {
 			It("should set given headers to request", func() {
 				var obj IBObject
-				req, _ := wrb.BuildRequest(GET, obj, "ref", nil)
+				req, _ := wrbh.BuildRequest(GET, obj, "ref", nil)
 				for k := range header {
 					Expect(header.Get(k)).To(Equal(req.Header.Get(k)))
 				}


### PR DESCRIPTION
the new type can be used like the following

``` go
header := make(http.Header)
header.Add("x", "1")
header.Add("y", "2")

wrb, _ := NewWapiRequestBuilder(hostCfg, authCfg)
wrbh, err := NewWapiRequestBuilderWithHeaders(wrb, header)