### PR TITLE
Remove omitempty json tag from dns/dhcp struct

### DIFF
--- a/objects.go
+++ b/objects.go
@@ -469,7 +469,7 @@ type Dns struct {
 	Comment     string `json:"comment,omitempty"`
 	HostName    string `json:"host_name,omitempty"`
 	IPv4Address string `json:"ipv4addr,omitempty"`
-	EnableDns   bool   `json:"enable_dns,omitempty"`
+	EnableDns   bool   `json:"enable_dns"`
 }
 
 func (d Dns) ObjectType() string {
@@ -492,7 +492,7 @@ type Dhcp struct {
 	Comment     string `json:"comment,omitempty"`
 	HostName    string `json:"host_name,omitempty"`
 	IPv4Address string `json:"ipv4addr,omitempty"`
-	EnableDns   bool   `json:"enable_dns,omitempty"`
+	EnableDns   bool   `json:"enable_dns"`
 }
 
 func (d Dhcp) ObjectType() string {


### PR DESCRIPTION
* Remove `omitempty` json tag from DNS and DHCP struct
* As in request build method, json marshal will remove zero values of the field. But EnableDns/EnableDhcp is required in the body.