### PR TITLE
adding wrapper method for Range object

### DIFF
--- a/object_manager.go
+++ b/object_manager.go
@@ -95,6 +95,10 @@ type IBObjectManager interface {
 	UpdateDnsStatus(ref string, status bool) (Dns, error)
 	GetDhcpMember(ref string) ([]Dhcp, error)
 	UpdateDhcpStatus(ref string, status bool) (Dhcp, error)
+	CreateRange(netView, name, startAddr, endAddr, comment string, disable bool, exclude []*Exclusionrange) (*Range, error)
+	UpdateRange(ref, name, startAddr, endAddr, comment string, disable bool, exclude []*Exclusionrange) (*Range, error)
+	GetRange(ref string) (*Range, error)
+	DeleteRange(ref string) error
 }
 
 type ObjectManager struct {

--- a/object_manager_range.go
+++ b/object_manager_range.go
@@ -1,0 +1,74 @@
+package ibclient
+
+import (
+	"fmt"
+)
+
+func (objMgr *ObjectManager) CreateRange(netViewName, name, startAddr, endAddr, comment string, disable bool, exclude []*Exclusionrange) (*Range, error) {
+	newRange := NewEmptyRange()
+	newRange.Name = &name
+	newRange.StartAddr = &startAddr
+	newRange.EndAddr = &endAddr
+	newRange.Comment = &comment
+	newRange.NetworkView = &netViewName
+	newRange.Exclude = exclude
+	newRange.Disable = &disable
+
+	refCreatedObj, err := objMgr.connector.CreateObject(newRange)
+	if err != nil {
+		return nil, err
+	}
+
+	return objMgr.GetRange(refCreatedObj)
+}
+
+func (objMgr *ObjectManager) UpdateRange(ref, name, startAddr, endAddr, comment string, disable bool, exclude []*Exclusionrange) (*Range, error) {
+	r := &Range{
+		Comment: &comment,
+		Disable: &disable,
+	}
+
+	if len(exclude) > 0 {
+		r.Exclude = exclude
+	}
+
+	if len(startAddr) > 0 {
+		r.StartAddr = &startAddr
+	}
+
+	if len(endAddr) > 0 {
+		r.EndAddr = &endAddr
+	}
+
+	if len(name) > 0 {
+		r.Name = &name
+	}
+
+	updateRef, err := objMgr.connector.UpdateObject(r, ref)
+	if err != nil {
+		return nil, err
+	}
+
+	return objMgr.GetRange(updateRef)
+}
+
+func (objMgr *ObjectManager) GetRange(ref string) (*Range, error) {
+	var res []Range
+	search := &Range{Ref: ref}
+	qp := NewQueryParams(false, nil)
+	err := objMgr.connector.GetObject(search, ref, qp, &res)
+	if err != nil {
+		return nil, err
+	} else if res == nil || len(res) == 0 {
+		return nil, NewNotFoundError(
+			fmt.Sprintf(
+				"could not find range object"))
+	}
+
+	return &res[0], nil
+}
+
+func (objMgr *ObjectManager) DeleteRange(ref string) error {
+	_, err := objMgr.connector.DeleteObject(ref)
+	return err
+}

--- a/object_manager_range_test.go
+++ b/object_manager_range_test.go
@@ -1,0 +1,61 @@
+package ibclient
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Object Manager: range create", func() {
+	Describe("Create IP Range", func() {
+		cmpType := "Docker"
+		tenantID := "01234567890abcdef01234567890abcdef"
+		netviewName := "private"
+		comment := "test"
+
+		startAddr := "10.10.0.1"
+		endAddr := "10.10.0.100"
+		rangeName := "rangeObj"
+		disable := false
+
+		fakeRefReturn := fmt.Sprintf("range/ZG5zLmJpbmRfY25h:%s/%s/%s", startAddr, endAddr, netviewName)
+
+		rangeObj := NewEmptyRange()
+		rangeObj.StartAddr = &startAddr
+		rangeObj.EndAddr = &endAddr
+		rangeObj.Name = &rangeName
+		rangeObj.Comment = &comment
+		rangeObj.NetworkView = &netviewName
+		rangeObj.Disable = &disable
+
+		resultObj := NewEmptyRange()
+		resultObj.StartAddr = &startAddr
+		resultObj.EndAddr = &endAddr
+		resultObj.Name = &rangeName
+		resultObj.NetworkView = &netviewName
+		resultObj.Comment = &comment
+		resultObj.Disable = &disable
+
+		getRangeObj := NewEmptyRange()
+		getRangeObj.Ref = fakeRefReturn
+
+		conn := &fakeConnector{
+			createObjectObj:      rangeObj,
+			getObjectObj:         getRangeObj,
+			getObjectRef:         fakeRefReturn,
+			getObjectQueryParams: NewQueryParams(false, nil),
+			resultObject:         []Range{*resultObj},
+			fakeRefReturn:        fakeRefReturn,
+		}
+
+		objMgr := NewObjectManager(conn, cmpType, tenantID)
+
+		It("should pass expected Range to CreateObject", func() {
+			createdRange, err := objMgr.CreateRange(netviewName, rangeName, startAddr, endAddr, comment, disable, nil)
+			Expect(err).To(BeNil())
+			Expect(createdRange.EndAddr).To(Equal(resultObj.EndAddr))
+			Expect(createdRange.NetworkView).To(Equal(resultObj.NetworkView))
+		})
+	})
+})

--- a/object_manager_test.go
+++ b/object_manager_test.go
@@ -88,6 +88,8 @@ func (c *fakeConnector) GetObject(obj IBObject, ref string, qp *QueryParams, res
 			*res.(*[]RecordA) = c.resultObject.([]RecordA)
 		case *RecordMX:
 			*res.(*[]RecordMX) = c.resultObject.([]RecordMX)
+		case *Range:
+			*res.(*[]Range) = c.resultObject.([]Range)
 		}
 	} else {
 		switch obj.(type) {
@@ -121,6 +123,8 @@ func (c *fakeConnector) GetObject(obj IBObject, ref string, qp *QueryParams, res
 			*res.(*[]Dns) = c.resultObject.([]Dns)
 		case *Dhcp:
 			*res.(*[]Dhcp) = c.resultObject.([]Dhcp)
+		case *Range:
+			*res.(*[]Range) = c.resultObject.([]Range)
 		}
 	}
 

--- a/objects.go
+++ b/objects.go
@@ -506,3 +506,7 @@ func NewDhcp(dhcp Dhcp) *Dhcp {
 	result.returnFields = returnFields
 	return &result
 }
+
+func NewEmptyRange() *Range {
+	return &Range{}
+}


### PR DESCRIPTION
At present, we do not have the Range API present to be called to create/update NIOS objects. Adding the same to object_manager.go (IBObjectManager interface).
Adding CreateRange/UpdateRange/GetRange/DeleteRange APIs. 