### PR TITLE
Add more general method to execute MultiRequests

### DIFF
--- a/object_manager.go
+++ b/object_manager.go
@@ -377,6 +377,29 @@ func (objMgr *ObjectManager) CreateMultiObject(req *MultiRequest) ([]map[string]
 	return result, nil
 }
 
+// DoMultiRequest executes the given MultiRequest and unmarshals the response into a list
+// of arbitrary values.
+// Result entries are - depending on the executed request - either [][]interface{} or []map[string]interface{}.
+func (objMgr *ObjectManager) DoMultiRequest(req *MultiRequest) ([]interface{}, error) {
+
+	conn := objMgr.connector.(*Connector)
+	queryParams := NewQueryParams(false, nil)
+	res, err := conn.makeRequest(CREATE, req, "", queryParams)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute multi object request: %w", err)
+	}
+
+	var result []interface{}
+	err = json.Unmarshal(res, &result)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse multi object request response: %w", err)
+	}
+
+	return result, nil
+}
+
 // GetUpgradeStatus returns the grid upgrade information
 func (objMgr *ObjectManager) GetUpgradeStatus(statusType string) ([]UpgradeStatus, error) {
 	var res []UpgradeStatus


### PR DESCRIPTION
Infoblox offers the possibility to do MultiRequests with it's API. This is a powerful feature to use.

However, the current go client does not correctly support this API. The parsing of the responses is to restricted as is.

This PR adds a method to execute any type of MultiRequest and parses the result into the least specific structure a response can have.

I'm not sure if this method should be added to the IBObjectManager interface as well or rather not cause it seems to be an underutilized/rudimentarily supported/used feature.

PS: I could need some support to add testcases for this type of request because I could not find any for the existing MultiRequest related method to use as an example to work with.