### PR TITLE
log previously silent error

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -56,7 +56,7 @@ func NewTransportConfig(sslVerify string, httpRequestTimeout int, httpPoolConnec
 			return
 		}
 		if !caPool.AppendCertsFromPEM(cert) {
-			err = fmt.Errorf("cannot append certificate from file '%s'", sslVerify)
+			log.Printf("cannot append certificate from file '%s'", sslVerify)
 			return
 		}
 		cfg.certPool = caPool


### PR DESCRIPTION
`NewTransportConfig()` does not return an `error`, though it does log errors before giving up.

The `error` from `caPool.AppendCertsFromPEM()` was being formatted with some contextual information, but then nothing was being done with it. This changes to a `log.Printf()` as used immediately previously in the function to report the reason for returning early.