### PR TITLE
[DDIDNS-8972] - Remove omitempty from SVCParams.SvcValue to fix NIOS SVCB creation

### DIFF
--- a/objects.go
+++ b/objects.go
@@ -781,7 +781,7 @@ type RecordSVCB struct {
 type SVCParams struct {
 	Mandatory bool     `json:"mandatory"`
 	SvcKey    string   `json:"svc_key,omitempty"`
-	SvcValue  []string `json:"svc_value,omitempty"`
+	SvcValue  []string `json:"svc_value"`
 }
 
 func (RecordSVCB) ObjectType() string {


### PR DESCRIPTION
## Summary

Remove `omitempty` from `SVCParams.SvcValue` JSON tag to fix SVCB/HTTPS record creation on NIOS for valueless SVC parameters (e.g., `ohttp`, `no-default-alpn`).

### Related

- JIRA: DDIDNS-8972

## Problem

NIOS WAPI requires `svc_value` to always be present as an array in `svc_parameters`, even when the parameter has no value (e.g., `ohttp`). With `omitempty`, Go's `json.Marshal` drops the field when the slice is nil or empty (`len == 0`), producing:

```json
{"svc_key": "ohttp", "mandatory": false}
```

This causes NIOS to return:
```
AdmConError: None (object of type 'NoneType' has no len())
```

## Fix

Remove `omitempty` from `SvcValue` so empty slices serialize as `"svc_value":[]`:

```diff
- SvcValue  []string `json:"svc_value,omitempty"`
+ SvcValue  []string `json:"svc_value"`
```

### Verified with live NIOS WAPI tests

| Request | Result |
|---------|--------|
| `svc_value` omitted | ❌ `NoneType has no len()` |
| `"svc_value": []` | ✅ Success |
| `"svc_value": null` | ❌ `List value expected` |

## Changes

| File | Action | Description |
|------|--------|-------------|
| `objects.go` | Modified | Remove `omitempty` from `SVCParams.SvcValue` JSON tag |

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Testing

- Verified with live NIOS WAPI v2.14 grid
- Confirmed empty array serialization with Go `encoding/json`
- All existing tests pass in downstream consumer (ddi.cloud.write.proxy)
